### PR TITLE
Support for PyTorch implementation of SVD

### DIFF
--- a/weightwatcher/RMT_Util.py
+++ b/weightwatcher/RMT_Util.py
@@ -31,11 +31,11 @@ try:
     import torch
     if torch.cuda.is_available():
         to_np = lambda t: t.to("cpu").numpy()
-        def svd_full_fast(M):
+        def _svd_full_fast(M):
             U, S, Vh = torch.linalg.svd(torch.Tensor(M).to("cuda"))
             return to_np(U), to_np(S), to_np(Vh)
-        def svd_vals_fast(M):
-            S = torch.linalg.svd_vals(torch.Tensor(M).to("cuda"))
+        def _svd_vals_fast(M):
+            S = torch.linalg.svdvals(torch.Tensor(M).to("cuda"))
             return to_np(S)
     else:
         logger = logging.getLogger(WW_NAME)

--- a/weightwatcher/constants.py
+++ b/weightwatcher/constants.py
@@ -15,6 +15,7 @@
 
 from enum import IntFlag, auto, Enum
 
+WW_NAME = 'weightwatcher'
 
 ERROR = -1
 
@@ -23,8 +24,11 @@ DEF_SAVE_DIR = 'ww-img'
 LAYERS = 'layers'
 START_IDS = 'layer_ids_start' # 0 | 1
 
-TRUNCATED_SVD = 'truncated_svd'
-FULL_SVD = 'full_svd'
+TRUNCATED_SVD = 'truncated'
+ACCURATE_SVD = 'accurate'
+FAST_SVD = 'fast'
+SVD_METHOD = 'svd_method'
+VALID_SVD_METHODS = [FAST_SVD, ACCURATE_SVD]    # Add TRUNCATED_SVD here when ready to enable
 
 # fi_ fingers options
 XMIN_PEAK = 'xmin_peak'
@@ -77,7 +81,6 @@ GLOROT_FIT = 'glorot_fit'
 WW2X = 'ww2x'
 VECTORS = 'vectors'
 SMOOTH = 'smooth'
-SVD_METHOD = 'svd_method'
 FIX_FINGERS = 'fix_fingers'
 MP_FIT = 'mp_fit'
 FIT = 'fit'
@@ -116,7 +119,7 @@ DEFAULT_PARAMS = {GLOROT_FIX: False, NORMALIZE:False, CONV2D_NORM:True, RANDOMIZ
                   SAVEDIR:DEF_SAVE_DIR, SAVEFIG:True, RESCALE:True, PLOT:False,
                   DELTA_ES:False, INTRA:False, CHANNELS_STR:None, CONV2D_FFT:False, 
                   WW2X:False, VECTORS:True, SMOOTH:None, STACKED:False, 
-                  SVD_METHOD:FULL_SVD,  FIX_FINGERS:None, FIT:POWER_LAW, 
+                  SVD_METHOD:ACCURATE_SVD,  FIX_FINGERS:None, FIT:POWER_LAW,
                   SPARSIFY: True, DETX: True,  MP_FIT:False,
                   MIN_EVALS:DEFAULT_MIN_EVALS, MAX_EVALS:DEFAULT_MAX_EVALS, MAX_N:DEFAULT_MAX_N,
                   TOLERANCE:WEAK_RANK_LOSS_TOLERANCE, START_IDS:DEFAULT_START_ID, ADD_BIASES:False}

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -2075,7 +2075,7 @@ class WeightWatcher(object):
                 fix_fingers=False, xmin_max = None,  max_N=10,
                 fit=PL, sparsify=True, 
                 detX=False,
-                svd_method=ACCURATE_SVD,
+                svd_method=FAST_SVD,
                 tolerance=WEAK_RANK_LOSS_TOLERANCE,
                 start_ids=0):
         """
@@ -2173,7 +2173,7 @@ class WeightWatcher(object):
         detX:  bool, default: False 
             compute the Trace Log Norm / DetX=1 constraint, and plot if plot True
 
-        svd_method:  string, default: 'accurate'
+        svd_method:  string, default: 'fast'
             Must be one of "fast" or "accurate". Determines the method by which eigenvalues are calcualted.
             
         tolerance: float, default 0.000001


### PR DESCRIPTION
The following changes are made:

- All invocations of `scipy.linalg.svd` are replaced with new functions `svd_vals` when only singular values are needed, or `svd_full` when the whole U, S, V decomposition is needed. (Pytorch has separate functions for these.)
- In RMT_Util.py checks are made for torch availability, and for CUDA availability. If both of these pass, then functions `_svd_full_fast` and `_svd_vals_fast` are defined, which wrap `torch.linalg.svd` and `torch.linalg.svdvals` respectively. If the checks don't pass, then those functions are aliased onto `_svd_full_accurate` and `_svd_vals_accurate` which wrap `scipy.linalg.svd`.
- A new parameter `svd_method` is added to `analyze` which must be either "fast" or "accurate". The default value is "accurate". This parameter is passed to the functions `svd_full` and `svd_vals` defined in `RMT_Util.py` which multiplex the underlying SVD method.
- `WW_name` moved to constants.py so that it can be used for logging in `RMT_Util.py`.

If the `svd_vals` argument is not set when calling `analyze`, then it will function exactly as it did prior to this PR.