### PR TITLE
Issue 180 streamlined / centralized imports from torch, tf, keras onnx

### DIFF
--- a/weightwatcher/RMT_Util.py
+++ b/weightwatcher/RMT_Util.py
@@ -135,6 +135,26 @@ except ImportError:
     pass
 
 
+# Handle onnx imports
+onnx_version = "unavailable"
+onnx_get_weights = lambda node: \
+    logger.fatal("Attempting to load an ONNX weight matrix but onnx is unavailable")
+onnx_set_weights = lambda node: \
+    logger.fatal("Attempting to set an ONNX weight matrix but onnx is unavailable")
+try:
+    import onnx
+    onnx_version = onnx.__version__
+
+    from onnx import numpy_helper
+    onnx_get_weights = lambda node: numpy_helper.to_array(node) #@pydevd suppress warning
+    onnx_set_weights = lambda layer, idx, W: \
+        layer.model.graph.initializer[idx].CopyFrom(
+            numpy_helper.from_array(W) #@pydevd suppress warning
+        )
+except ImportError:
+    pass
+
+
 # ## Generalized Entropy
 # Trace Normalization
 #def matrix_entropy_(W):

--- a/weightwatcher/RMT_Util.py
+++ b/weightwatcher/RMT_Util.py
@@ -7,7 +7,6 @@ import sys, os
 import warnings
 
 from joblib._multiprocessing_helpers import mp
-import matplotlib
 import powerlaw
 from scipy import optimize, stats
 from sklearn.neighbors import KernelDensity
@@ -15,7 +14,6 @@ import tqdm
 
 import matplotlib.pyplot as plt
 import numpy as np
-import pandas as pd
 import scipy as sp
 import scipy.stats as stats
 
@@ -699,6 +697,7 @@ def fit_density_with_range(evals, Q, bw=0.1, sigma_range=(slice(0.1, 1.25, 0.01)
     
     return brute_output[0][0], brute_output[1]  # sigma_optimized, resid
 
+# import pandas as pd
 # def fit_mp_findspikes(evals, Q):
 #     '''Remove eigen (spikes) from largest to smallest'''
 #     evals = sorted(evals)[::-1]

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -16,21 +16,17 @@ import sys, os, re, io
 import glob, json
 import traceback
 import tempfile
-import logging
 
 #from deprecated import deprecated
 import inspect
 
 import numpy as np
 import pandas as pd
-import scipy as sp
-
-import matplotlib
+from scipy import stats
 import matplotlib.pyplot as plt
 import powerlaw
 
 
-import sklearn
 from sklearn.decomposition import TruncatedSVD
 
 from copy import deepcopy
@@ -55,7 +51,6 @@ import importlib
 
 from .RMT_Util import *
 from .constants import *
-from numpy import vectorize
 
 
 # WW_NAME moved to constants.py
@@ -1167,7 +1162,7 @@ class WWStackedLayerIterator(WWLayerIterator):
             #Height, Width = W.shape[0], W.shape[1]
                
             #W = W/np.linalg.norm(W)
-            W = (W - np.median(W))/sp.stats.median_abs_deviation(W)
+            W = (W - np.median(W))/stats.median_abs_deviation(W)
             W = np.pad(W, ((0, 0), (0, Mmax-Width)) ) 
             Wmats_padded.append(W)
                 

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -163,13 +163,10 @@ class ONNXLayer:
             logger.debug("Unsupported ONNX Layer, dims = {}".format(self.dims))
             
     def get_weights(self):
-        return numpy_helper.to_array(self.node) #@pydevd suppress warning
+        return onnx_get_weights(self.node)
 
-
-    
     def set_weights(self, idx, W):
-        T = numpy_helper.from_array(W) #@pydevd suppress warning
-        self.model.graph.initializer[idx].CopyFrom(T)
+        onnx_set_weights(self, idx, W)
 
         
         
@@ -425,8 +422,7 @@ class WWLayer:
   
 
         elif self.framework == FRAMEWORK.ONNX:      
-            onnx_layer = self.layer
-            weights = onnx_layer.get_weights()
+            weights = self.layer.get_weights()
             has_weights = True
             
         elif self.framework == FRAMEWORK.PYSTATEDICT:      
@@ -1306,9 +1302,7 @@ class WeightWatcher(object):
             banner = f"torch version {torch_version}"
 
         elif framework==FRAMEWORK.ONNX:
-            import onnx
-            from onnx import numpy_helper
-            banner = f"onnx version {onnx.__version__}"   
+            banner = f"onnx version {onnx_version}"
         else:
             logger.warning(f"Unknown or unsupported framework {framework}")
             banner = ""

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -1283,13 +1283,6 @@ class WeightWatcher(object):
 
         banner = ""
         if framework==FRAMEWORK.KERAS:
-            #import tensorflow as tf
-            #from tensorflow import keras
-            
-            #global tf, keras
-            #tf = importlib.import_module('tensorflow')
-            #keras = importlib.import_module('tensorflow.keras')
-        
             banner = f"tensorflow version {tf_version}"+"\n"
             banner += f"keras version {keras_version}"
             

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -21,11 +21,9 @@ import logging
 #from deprecated import deprecated
 import inspect
 
-
 import numpy as np
 import pandas as pd
 import scipy as sp
-import scipy.linalg
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -1611,7 +1609,6 @@ class WeightWatcher(object):
 
             W = W.astype(float)
             logger.debug("Running {} SVD:  W.shape={}  n_comp = {}".format(params[SVD_METHOD], W.shape, n_comp))
-            #sv = sp.linalg.svd(W, compute_uv=False)
             sv = svd_vals(W, method=params[SVD_METHOD])
             sv = sv.flatten()
             sv = np.sort(sv)[-n_comp:]
@@ -2606,7 +2603,6 @@ class WeightWatcher(object):
                 W = Wrand.reshape(W.shape)
                 W = W.astype(float)
                 logger.debug("Running Randomized Full SVD")
-                #sv = sp.linalg.svd(W, compute_uv=False)
                 sv = svd_vals(W, method=params[SVD_METHOD])
                 sv = sv.flatten()
                 sv = np.sort(sv)[-n_comp:]    
@@ -3258,7 +3254,6 @@ class WeightWatcher(object):
         # TODO: replace this with truncated SVD
         # can't we just apply the svd transform...test
         # keep this old method for historical comparison
-        #u, s, vh = sp.linalg.svd(W, compute_uv=True)
         u, s, vh = svd_full(W, method=svd_method)
 
         # s is ordered highest to lowest
@@ -3700,7 +3695,7 @@ class WeightWatcher(object):
             else:
                 X = np.matmul(W.T, W)
 
-            evals, V = sp.linalg.eig(X)
+            evals, V = eig_full(W, method=params[SVD_METHOD])
             all_evals.extend(evals)
 
             vec_entropies = []

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -313,25 +313,8 @@ class WWLayer:
         
         # Keras TF 2.x types
         if self.framework==FRAMEWORK.KERAS:
-            if isinstance(layer, keras.layers.Dense) or 'Dense' in str(type(layer)):
-                the_type = LAYER_TYPE.DENSE
-                
-            elif isinstance(layer, keras.layers.Conv1D)  or  'Conv1D' in str(type(layer)):               
-                the_type = LAYER_TYPE.CONV1D
-            
-            elif isinstance(layer, keras.layers.Conv2D) or 'Conv2D' in str(type(layer)):             
-                the_type = LAYER_TYPE.CONV2D
-                                
-            elif isinstance(layer, keras.layers.Flatten) or 'Flatten' in str(type(layer)):
-                the_type = LAYER_TYPE.FLATTENED
-                
-            elif isinstance(layer, keras.layers.Embedding) or 'Embedding' in str(type(layer)):
-                the_type = LAYER_TYPE.EMBEDDING
-                
-            elif isinstance(layer, tf.keras.layers.LayerNormalization) or 'LayerNorn' in str(type(layer)):
-                the_type = LAYER_TYPE.NORM
-        
-        # PyTorch        
+            the_type = keras_infer_T(layer)
+        # PyTorch
         elif self.framework==FRAMEWORK.PYTORCH:
             the_type = torch_infer_T(layer)
 
@@ -1261,8 +1244,8 @@ class WeightWatcher(object):
     def banner(self):
         versions = "\npython      version {}".format(sys.version)
         versions += "\nnumpy       version {}".format(np.__version__)            
-        #versions += "\ntensforflow version {}".format(tf.__version__)
-        #versions += "\nkeras       version {}".format(tf.keras.__version__)
+        #versions += "\ntensforflow version {}".format(tf_version)
+        #versions += "\nkeras       version {}".format(keras_version)
         return "\n{}{}".format(self.header(), versions)
 
     def __repr__(self):
@@ -1312,12 +1295,12 @@ class WeightWatcher(object):
             #import tensorflow as tf
             #from tensorflow import keras
             
-            global tf, keras
-            tf = importlib.import_module('tensorflow')
-            keras = importlib.import_module('tensorflow.keras')
+            #global tf, keras
+            #tf = importlib.import_module('tensorflow')
+            #keras = importlib.import_module('tensorflow.keras')
         
-            banner = f"tensorflow version {tf.__version__}"+"\n"
-            banner += f"keras version {keras.__version__}"
+            banner = f"tensorflow version {tf_version}"+"\n"
+            banner += f"keras version {keras_version}"
             
         elif framework==FRAMEWORK.PYTORCH or framework==FRAMEWORK.PYSTATEDICT:
             banner = f"torch version {torch_version}"


### PR DESCRIPTION
This PR does the following:
  - Changed the handled exception type from `ModuleNotFoundError` to the more generic `ImportError`
  - Wrapped the eig function to use "fast" (pytorch/cuda) or "accurate" (scipy) depending on SVD_METHOD passed to analyze().
  - All invocations of torch, tf, keras and onnx are wrapped in functions defined in RMT_Util.py
  - For each of the above libraries, stub functions are defined which, if invoked, throw a fatal error.
    - Upon successful import of each of the above libraries the stub functions are overridden to replace functionality taken out of weightwatcher.py.
  - Some import statements were removed that are no longer being used.

Tests are currently running. I will update here when / if they pass, or otherwise fix and push to the branch.

Remaining issues:
  - How to directly test what happens when torch / tensorflow / onnx is unavailable
  - A test for the fast eig method similar to the test for svd.