### PR TITLE
Ignore layers where self.layer.weight is None

### DIFF
--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -325,6 +325,11 @@ class PyTorchLayer(FrameworkLayer):
         
         if hasattr(self.layer, 'weight'): 
             #w = [np.array(self.layer.weight.data.clone().cpu())]
+            
+            if self.layer.weight == None:
+                print(f"layer.layer.weight is None for {self.name}")
+                return False, None, False, None
+                            
             w = [torch_T_to_np(self.layer.weight.data)]
             
             if self.the_type==LAYER_TYPE.CONV2D:


### PR DESCRIPTION
Fix for:
```
    w = [torch_T_to_np(self.layer.weight.data)]
                       ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'data'
```
Where self.layer has the 'weight' attribute but it is None. 