### PR TITLE
Fix trap helper name collision in WeightWatcher

### DIFF
--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -5648,12 +5648,12 @@ class WeightWatcher:
         """Run ESD and MP fit in the trap workflow."""
         return remove_traps_ops.apply_trap_mp_fit(self, ww_layer, params=params)
 
-    def identify_trap_mode_indices(self, ww_layer):
-        """Identify outlier mode indices using MP + Tracy-Widom corrected edge."""
+    def identify_remove_trap_mode_indices(self, ww_layer):
+        """Backward-compatible wrapper for remove_traps helper mode detection."""
         return remove_traps_ops.identify_trap_mode_indices(self, ww_layer)
 
-    def analyze_single_trap(self, ww_layer, trap_mode_index):
-        """Extract a single rank-1 trap artifact from a permuted WWLayer."""
+    def analyze_single_remove_trap(self, ww_layer, trap_mode_index):
+        """Backward-compatible wrapper for remove_traps single-trap artifact extraction."""
         return remove_traps_ops.analyze_single_trap(self, ww_layer, trap_mode_index)
 
     def _collect_trap_artifacts(self, ww_layer, params=None, seed=None, rng=None):


### PR DESCRIPTION
### Motivation
- The class contained duplicate method names for trap analysis and remove-traps compatibility wrappers which caused `analyze_traps()` to dispatch to the wrong helper signatures at runtime (the later remove-traps wrappers overrode the trap-analysis methods).  

### Description
- Rename the remove-traps compatibility wrapper methods on `WeightWatcher` to `identify_remove_trap_mode_indices` and `analyze_single_remove_trap` so they no longer collide with the trap-analysis methods, and keep them delegating to `remove_traps_ops` helpers.  

### Testing
- Ran `pytest -q tests/test_analyze_traps.py tests/test_remove_traps.py`, which produced two failing tests in `tests/test_remove_traps.py` (`test_remove_traps_single_trap_flow` and `test_remove_traps_two_trap_index_selective_behavior`) and otherwise reported `2 failed, 2 passed, 13 skipped`, with warnings about invalid trap indices documented in the test output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9560356ec8320ad36d5fd8efab121)