### PR TITLE
Fix trap permutation RNG alignment across analysis and removal

### DIFF
--- a/weightwatcher/remove_traps.py
+++ b/weightwatcher/remove_traps.py
@@ -66,7 +66,9 @@ def collect_trap_artifacts(ww, ww_layer, params=None, seed=None, rng=None):
     if seed is None and isinstance(params, dict):
         seed = params.get("seed", None)
     if rng is None:
-        rng = np.random.default_rng(seed) if seed is not None else None
+        # Match analyze_traps(seed=int) behavior, which normalizes int seeds to
+        # numpy.random.RandomState for permutation reproducibility.
+        rng = np.random.RandomState(int(seed)) if seed is not None else None
 
     analysis_layer = ww_layer.copy()
     analysis_layer.Wmats = [ww_layer.Wmats[0].copy()]

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3039,7 +3039,11 @@ class WeightWatcher:
         logger.debug("apply permute W  on Layer {} {} ".format(layer_id, name))                        
         logger.debug("params {} ".format(params))
     
-        rng = params.get("rng", None)
+        # Prefer an explicit RNG passed by caller; otherwise fall back to params.
+        # This is important for remove_traps(), which may construct a layer-local RNG
+        # and pass it directly.
+        if rng is None:
+            rng = params.get("rng", None)
         Wmats, permute_ids = [], []
         for W in ww_layer.Wmats:
             W, p_ids = permute_matrix(W, rng=rng)


### PR DESCRIPTION
### Motivation
- The `analyze_traps()` and `remove_traps()` artifact pipeline could use different RNG plumbing even with the same seed, producing different permutations and causing trap-count/mode-index mismatches during alignment audits.

### Description
- `apply_permute_W()` now prefers an explicitly passed `rng` argument and only falls back to `params["rng"]` if none was provided, preserving caller-provided RNGs.
- `collect_trap_artifacts()` now constructs a `numpy.random.RandomState(int(seed))` when an integer seed is supplied to match `analyze_traps(seed=int)` permutation behavior.
- Added clarifying comments explaining the RNG choice to ensure consistent permutation behavior between analysis and removal codepaths.

### Testing
- Ran `pytest -q tests/test_remove_traps.py` and all tests completed with `4 passed, 2 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95a469738832088104dc32c749d9f)