### PR TITLE
Normalize RNG for trap permutations across analyze_traps and remove_traps

### DIFF
--- a/tests/test_remove_traps.py
+++ b/tests/test_remove_traps.py
@@ -245,6 +245,68 @@ def test_remove_traps_invalid_indices_warns_and_skips(monkeypatch, caplog):
 
 
 @pytest.mark.skipif(torch is None, reason="PyTorch not installed")
+def test_trap_rng_consistency_analyze_vs_collect_single_and_multi_layer():
+    model = torch.nn.Sequential(
+        torch.nn.Linear(16, 12, bias=False),
+        torch.nn.ReLU(),
+        torch.nn.Linear(12, 10, bias=False),
+    )
+    with torch.no_grad():
+        u1 = torch.linspace(1.0, 2.0, steps=12)
+        v1 = torch.linspace(-2.0, 1.0, steps=16)
+        model[0].weight.copy_(35.0 * torch.outer(u1, v1))
+
+        u2 = torch.linspace(1.0, 1.5, steps=10)
+        v2 = torch.linspace(-1.0, 2.0, steps=12)
+        model[2].weight.copy_(20.0 * torch.outer(u2, v2))
+
+    watcher = WeightWatcher(model=model)
+    details = watcher.describe(model=model, pool=True)
+    dense_layer_ids = details[details["layer_type"].astype(str).str.contains("dense", case=False)]["layer_id"].astype(int).tolist()
+    assert len(dense_layer_ids) >= 2
+
+    for layer_id in dense_layer_ids:
+        trap_df = watcher.analyze_traps(model=model, layers=[layer_id], rng=123, plot=False, savefig=False, pool=True)
+        expected_mode_indices = trap_df["perm_mode_index"].astype(int).tolist()
+
+        params = DEFAULT_PARAMS.copy()
+        params["pool"] = True
+        params["plot"] = False
+        params["layers"] = [layer_id]
+        params = watcher.normalize_params(params)
+        ww_layer = list(watcher.make_layer_iterator(model=watcher.model, layers=[layer_id], params=params))[0]
+        artifacts = watcher._collect_trap_artifacts(ww_layer, params=params, seed=123)
+        artifact_mode_indices = [int(a["trap_mode_index"]) for a in artifacts]
+
+        assert len(expected_mode_indices) == len(artifact_mode_indices)
+        assert expected_mode_indices == artifact_mode_indices
+
+
+@pytest.mark.skipif(torch is None, reason="PyTorch not installed")
+def test_analyze_traps_rejects_default_rng_generator():
+    model = torch.nn.Sequential(torch.nn.Linear(8, 8, bias=False))
+    watcher = WeightWatcher(model=model)
+    details = watcher.describe(model=model, pool=True)
+    layer_id = int(details[details["layer_type"].astype(str).str.contains("dense", case=False)].iloc[0]["layer_id"])
+    with pytest.raises(ValueError, match="RandomState|default_rng|Generator"):
+        watcher.analyze_traps(model=model, layers=[layer_id], rng=np.random.default_rng(123), plot=False, savefig=False)
+
+
+@pytest.mark.skipif(torch is None, reason="PyTorch not installed")
+def test_analyze_traps_accepts_randomstate_and_int_seed():
+    model = torch.nn.Sequential(torch.nn.Linear(8, 8, bias=False))
+    with torch.no_grad():
+        model[0].weight.copy_(torch.eye(8))
+    watcher = WeightWatcher(model=model)
+    details = watcher.describe(model=model, pool=True)
+    layer_id = int(details[details["layer_type"].astype(str).str.contains("dense", case=False)].iloc[0]["layer_id"])
+
+    df_seed = watcher.analyze_traps(model=model, layers=[layer_id], rng=123, plot=False, savefig=False)
+    df_state = watcher.analyze_traps(model=model, layers=[layer_id], rng=np.random.RandomState(123), plot=False, savefig=False)
+    assert list(df_seed["perm_mode_index"]) == list(df_state["perm_mode_index"])
+
+
+@pytest.mark.skipif(torch is None, reason="PyTorch not installed")
 def test_replace_layer_weights_preserves_dtype_device_directly():
     layer = torch.nn.Linear(8, 8, bias=True).to(dtype=torch.float32, device="cpu")
     wrapped = PyTorchLayer(layer, layer_id=0, name="linear")

--- a/weightwatcher/remove_traps.py
+++ b/weightwatcher/remove_traps.py
@@ -1,4 +1,5 @@
 import logging
+import numbers
 import numpy as np
 
 from .RMT_Util import svd_full, unpermute_matrix
@@ -7,6 +8,32 @@ from .constants import LAYERS
 from .constants import WW_NAME
 
 logger = logging.getLogger(WW_NAME)
+
+
+def _normalize_trap_rng(rng=None, seed=None):
+    """Normalize trap permutation RNG to a reproducible numpy RandomState."""
+    if rng is not None and seed is not None:
+        raise ValueError("Pass either rng or seed, not both, for trap permutation reproducibility.")
+
+    if rng is None and seed is None:
+        return None
+
+    if isinstance(rng, np.random.RandomState):
+        return rng
+
+    if isinstance(rng, np.random.Generator):
+        raise ValueError(
+            "Trap reproducibility requires numpy.random.RandomState or an int seed; "
+            "numpy.random.Generator (e.g., np.random.default_rng()) is not supported."
+        )
+
+    if isinstance(rng, numbers.Integral):
+        return np.random.RandomState(int(rng))
+
+    if isinstance(seed, numbers.Integral):
+        return np.random.RandomState(int(seed))
+
+    raise ValueError("rng/seed must be None, an int seed, or a numpy.random.RandomState.")
 
 
 def apply_trap_mp_fit(ww, ww_layer, params=None):
@@ -65,10 +92,7 @@ def collect_trap_artifacts(ww, ww_layer, params=None, seed=None, rng=None):
 
     if seed is None and isinstance(params, dict):
         seed = params.get("seed", None)
-    if rng is None:
-        # Match analyze_traps(seed=int) behavior, which normalizes int seeds to
-        # numpy.random.RandomState for permutation reproducibility.
-        rng = np.random.RandomState(int(seed)) if seed is not None else None
+    rng = _normalize_trap_rng(rng=rng, seed=seed)
 
     analysis_layer = ww_layer.copy()
     analysis_layer.Wmats = [ww_layer.Wmats[0].copy()]
@@ -101,7 +125,7 @@ def make_stat_matched_random_matrix(T, rng):
     return np.mean(T) + np.std(T) * G
 
 
-def apply_remove_traps(ww, ww_layer, trap_indices, params=None, seed=None):
+def apply_remove_traps(ww, ww_layer, trap_indices, params=None, seed=None, rng=None):
     if params is None:
         params = DEFAULT_PARAMS.copy()
     if trap_indices is None or len(trap_indices) == 0:
@@ -118,11 +142,19 @@ def apply_remove_traps(ww, ww_layer, trap_indices, params=None, seed=None):
     if layer_seed is None and isinstance(params, dict):
         layer_seed = params.get("seed", None)
 
+    permute_rng = _normalize_trap_rng(rng=rng, seed=layer_seed)
+
     permute_seed = layer_seed
     replacement_seed = None if layer_seed is None else layer_seed + 1
     replacement_rng = np.random.default_rng(replacement_seed)
 
-    artifacts = collect_trap_artifacts(ww, ww_layer, params=params, seed=permute_seed)
+    artifacts = collect_trap_artifacts(
+        ww,
+        ww_layer,
+        params=params,
+        seed=None if permute_rng is not None else permute_seed,
+        rng=permute_rng,
+    )
     valid_indices = [idx for idx in requested if idx <= len(artifacts)]
     if len(valid_indices) < len(requested):
         logger.warning(
@@ -146,7 +178,7 @@ def apply_remove_traps(ww, ww_layer, trap_indices, params=None, seed=None):
     return ww_layer
 
 
-def remove_traps(ww, model=None, layers=[], trap_indices=None, seed=None, pool=True, plot=False,
+def remove_traps(ww, model=None, layers=[], trap_indices=None, seed=None, rng=None, pool=True, plot=False,
                  start_ids=DEFAULT_START_ID, svd_method=FAST_SVD, base_model=None, peft=DEFAULT_PEFT):
     if trap_indices is None or len(trap_indices) == 0:
         raise ValueError("trap_indices must be provided and non-empty")
@@ -160,6 +192,7 @@ def remove_traps(ww, model=None, layers=[], trap_indices=None, seed=None, pool=T
     params[SVD_METHOD] = svd_method
     params[PEFT] = peft
     params["seed"] = seed
+    params["rng"] = _normalize_trap_rng(rng=rng, seed=seed)
 
     if not ww.__class__.valid_params(params):
         raise Exception(f"Error, params not valid: \n {params}")
@@ -168,6 +201,6 @@ def remove_traps(ww, model=None, layers=[], trap_indices=None, seed=None, pool=T
     layer_iterator = ww.make_layer_iterator(model=ww.model, layers=layers, params=params, base_model=base_model)
     for ww_layer in layer_iterator:
         if not ww_layer.skipped and ww_layer.has_weights:
-            apply_remove_traps(ww, ww_layer, trap_indices=trap_indices, params=params, seed=seed)
+            apply_remove_traps(ww, ww_layer, trap_indices=trap_indices, params=params, seed=seed, rng=params["rng"])
 
     return model

--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -1,8 +1,6 @@
-import numbers
-
-import numpy as np
 import pandas as pd
 
+from . import remove_traps as remove_traps_ops
 from . import weightwatcher as wwcore
 
 
@@ -72,11 +70,7 @@ def analyze_traps(
     params[wwcore.SAVEFIG] = savefig
     params[wwcore.PEFT] = peft
     params[wwcore.INVERSE] = False
-    if isinstance(rng, numbers.Integral):
-        rng = np.random.RandomState(int(rng))
-    if rng is not None and not hasattr(rng, "permutation"):
-        raise ValueError("rng must be None, an int seed, or a numpy RNG with a permutation method")
-    params["rng"] = rng
+    params["rng"] = remove_traps_ops._normalize_trap_rng(rng=rng)
 
     wwcore.logger.debug("params {}".format(params))
     if not watcher.valid_params(params):

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3721,7 +3721,7 @@ class WeightWatcher:
 
         Parameters
         ----------
-        rng : None, int, numpy.random.RandomState, or numpy.random.Generator
+        rng : None, int, or numpy.random.RandomState
             Optional random source used for reversible trap permutations.
             Passing the same seed/object makes trap detection reproducible across runs.
         """
@@ -5652,15 +5652,15 @@ class WeightWatcher:
         """Build a random matrix with matched shape, mean, and variance."""
         return remove_traps_ops.make_stat_matched_random_matrix(T, rng)
 
-    def apply_remove_traps(self, ww_layer, trap_indices, params=None, seed=None):
+    def apply_remove_traps(self, ww_layer, trap_indices, params=None, seed=None, rng=None):
         """Remove selected traps from one dense WWLayer and replace with matched random matrices."""
-        return remove_traps_ops.apply_remove_traps(self, ww_layer, trap_indices, params=params, seed=seed)
+        return remove_traps_ops.apply_remove_traps(self, ww_layer, trap_indices, params=params, seed=seed, rng=rng)
 
-    def remove_traps(self, model=None, layers=[], trap_indices=None, seed=None, pool=True, plot=False,
+    def remove_traps(self, model=None, layers=[], trap_indices=None, seed=None, rng=None, pool=True, plot=False,
                      start_ids=DEFAULT_START_ID, svd_method=FAST_SVD, base_model=None, peft=DEFAULT_PEFT):
         """Remove selected randomized MP/TW traps from dense layers."""
         return remove_traps_ops.remove_traps(
-            self, model=model, layers=layers, trap_indices=trap_indices, seed=seed,
+            self, model=model, layers=layers, trap_indices=trap_indices, seed=seed, rng=rng,
             pool=pool, plot=plot, start_ids=start_ids, svd_method=svd_method, base_model=base_model, peft=peft
         )
 


### PR DESCRIPTION
### Motivation
- The trap detection pipeline used inconsistent RNG handling: `analyze_traps()` accepted `np.random.Generator` or `RandomState` while removal code rebuilt RNGs from `seed` using `np.random.RandomState`, causing mismatched permutations for the same nominal seed.
- The change centralizes RNG normalization so the same model/layer/seed yields identical permutations and trap detection results across analysis and removal code paths.

### Description
- Added a shared helper ` _normalize_trap_rng(rng=None, seed=None)` in `weightwatcher/remove_traps.py` that enforces mutual exclusivity of `rng` and `seed`, accepts `None`, int-like seeds, or `np.random.RandomState`, and rejects `np.random.Generator` with a clear `ValueError` message.
- Updated `trap_analysis.analyze_traps()` to call the shared helper and store the normalized `RandomState` into `params['rng']`, so analyze-side permutations use the same RNG normalization as removal-side code.
- Updated `collect_trap_artifacts()`, `apply_remove_traps()`, and the public `remove_traps(...)` path to use the shared helper and to accept an optional `rng` parameter (kept `replacement_rng` separate and still uses `default_rng` for replacement matrices).
- Updated `WeightWatcher` wrappers so `apply_remove_traps(...)` and `remove_traps(...)` accept and pass `rng` through the normalized path without changing trap math or threshold logic.

### Testing
- Added regression tests in `tests/test_remove_traps.py` to assert parity between `analyze_traps(..., rng=seed)` and `_collect_trap_artifacts(..., seed=seed)`, to assert rejection of `np.random.default_rng(...)`, and to assert `RandomState` and int seeds work; these tests are present and skipped in CI when PyTorch is unavailable.
- Ran `pytest` on targeted remove-traps flows and the existing single- and two-trap removal tests (`test_remove_traps_single_trap_flow` and `test_remove_traps_two_trap_index_selective_behavior`) which passed locally.
- Executed the new RNG regression tests and the analyze-traps reproducibility test in this environment; they were skipped because PyTorch is not available here, and a repository search (`rg`) confirmed trap permutation code paths now use the shared normalizer.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d95ff90f7c832094601a7f1a14f178)