### PR TITLE
Downweight trap risk by diffuseness (diffuse-corrected scoring)

### DIFF
--- a/tests/test_trap_diffuseness.py
+++ b/tests/test_trap_diffuseness.py
@@ -71,6 +71,107 @@ class TestTrapDiffuseness(unittest.TestCase):
         self.assertLess(loc_out["trap_diffuseness_score"], dif_out["trap_diffuseness_score"])
         self.assertGreaterEqual(loc_out["trap_risk_score"], dif_out["trap_risk_score"])
 
+    def test_risk_score_decreases_monotonically_with_diffuseness_for_fixed_strength(self):
+        base = {
+            "u_length": 20,
+            "v_length": 20,
+            "trap_eval_minus_bulk": 0.8,
+            "mp_bulk_max": 1.0,
+        }
+        low_diff = dict(base, **{
+            "u_effective_support": 1.0,
+            "v_effective_support": 1.0,
+            "u_squared_amp_entropy": 0.1,
+            "v_squared_amp_entropy": 0.1,
+            "u_top1_mass": 0.95,
+            "v_top1_mass": 0.95,
+            "u_gini_abs": 0.95,
+            "v_gini_abs": 0.95,
+            "left_top_mass": 0.95,
+            "right_top_mass": 0.95,
+        })
+        mid_diff = dict(base, **{
+            "u_effective_support": 10.0,
+            "v_effective_support": 10.0,
+            "u_squared_amp_entropy": 1.5,
+            "v_squared_amp_entropy": 1.5,
+            "u_top1_mass": 0.4,
+            "v_top1_mass": 0.4,
+            "u_gini_abs": 0.6,
+            "v_gini_abs": 0.6,
+            "left_top_mass": 0.4,
+            "right_top_mass": 0.4,
+        })
+        high_diff = dict(base, **{
+            "u_effective_support": 20.0,
+            "v_effective_support": 20.0,
+            "u_squared_amp_entropy": 3.0,
+            "v_squared_amp_entropy": 3.0,
+            "u_top1_mass": 0.0,
+            "v_top1_mass": 0.0,
+            "u_gini_abs": 0.0,
+            "v_gini_abs": 0.0,
+            "left_top_mass": 0.0,
+            "right_top_mass": 0.0,
+        })
+
+        out_low = self.watcher.assess_trap_diffuseness(low_diff)
+        out_mid = self.watcher.assess_trap_diffuseness(mid_diff)
+        out_high = self.watcher.assess_trap_diffuseness(high_diff)
+
+        self.assertLessEqual(out_low["trap_diffuseness_score"], out_mid["trap_diffuseness_score"])
+        self.assertLessEqual(out_mid["trap_diffuseness_score"], out_high["trap_diffuseness_score"])
+        self.assertGreaterEqual(out_low["trap_risk_score"], out_mid["trap_risk_score"])
+        self.assertGreaterEqual(out_mid["trap_risk_score"], out_high["trap_risk_score"])
+
+    def test_risk_score_is_zero_when_diffuseness_is_one(self):
+        trap = {
+            "u_length": 20,
+            "v_length": 20,
+            "u_effective_support": 20.0,
+            "v_effective_support": 20.0,
+            "u_squared_amp_entropy": 3.0,
+            "v_squared_amp_entropy": 3.0,
+            "u_top1_mass": 0.0,
+            "v_top1_mass": 0.0,
+            "u_gini_abs": 0.0,
+            "v_gini_abs": 0.0,
+            "left_top_mass": 0.0,
+            "right_top_mass": 0.0,
+            "trap_eval_minus_bulk": 999.0,
+            "mp_bulk_max": 1.0,
+        }
+        out = self.watcher.assess_trap_diffuseness(trap)
+        self.assertEqual(out["trap_diffuseness_score"], 1.0)
+        self.assertEqual(out["trap_risk_score"], 0.0)
+        self.assertEqual(out["trap_assessment"], "benign_diffuse")
+
+    def test_risk_score_matches_base_strength_when_diffuseness_is_zero(self):
+        trap = {
+            "u_length": 20,
+            "v_length": 20,
+            "u_effective_support": 0.0,
+            "v_effective_support": 0.0,
+            "u_squared_amp_entropy": 0.0,
+            "v_squared_amp_entropy": 0.0,
+            "u_top1_mass": 1.0,
+            "v_top1_mass": 1.0,
+            "u_gini_abs": 1.0,
+            "v_gini_abs": 1.0,
+            "left_top_mass": 1.0,
+            "right_top_mass": 1.0,
+            "trap_eval_minus_bulk": 0.3,
+            "mp_bulk_max": 2.0,
+        }
+        out = self.watcher.assess_trap_diffuseness(trap)
+        self.assertEqual(out["trap_diffuseness_score"], 0.0)
+        self.assertAlmostEqual(out["trap_risk_score"], 0.15, places=8)
+
+        trap_hi = dict(trap, **{"trap_eval_minus_bulk": 5.0, "mp_bulk_max": 1.0})
+        out_hi = self.watcher.assess_trap_diffuseness(trap_hi)
+        self.assertEqual(out_hi["trap_diffuseness_score"], 0.0)
+        self.assertEqual(out_hi["trap_risk_score"], 1.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3947,8 +3947,8 @@ class WeightWatcher:
     def assess_trap_diffuseness(self, trap_result):
         """Heuristic classifier for trap severity in original weight space.
 
-        Localized traps are treated as higher risk, while diffuse traps are treated as
-        potentially benign overfitting. This is intentionally a separate function so it
+        Trap risk is computed from normalized trap strength and then explicitly
+        downweighted by diffuseness. This is intentionally a separate function so it
         can be unit-tested and adjusted independently.
         """
         eps = 1e-12
@@ -3979,13 +3979,14 @@ class WeightWatcher:
 
         trap_strength = float(trap_result.get("trap_eval_minus_bulk", 0.0))
         bulk = abs(float(trap_result.get("mp_bulk_max", 0.0))) + eps
-        normalized_strength = trap_strength / bulk
-        risk_score = float(np.clip((1.0 - diffuseness_score) * max(normalized_strength, 0.0), 0.0, 1.0))
+        base_strength = max(trap_strength, 0.0) / bulk
+        diffuseness_score = float(np.clip(diffuseness_score, 0.0, 1.0))
+        risk_score = float(np.clip(base_strength * (1.0 - diffuseness_score), 0.0, 1.0))
 
-        if diffuseness_score >= 0.55 and risk_score < 0.30:
-            assessment = "benign_diffuse"
-        elif diffuseness_score <= 0.35 or risk_score >= 0.50:
+        if risk_score >= 0.50:
             assessment = "localized_risky"
+        elif diffuseness_score >= 0.55:
+            assessment = "benign_diffuse"
         else:
             assessment = "mixed"
 


### PR DESCRIPTION
### Motivation
- The existing internal trap `trap_risk_score` overestimated risk for highly diffuse traps and did not reflect ablation results where diffuse traps caused little damage. 
- We want the risk score to explicitly decrease with diffuseness while preserving the current trap analysis outputs and diffuseness computation.

### Description
- Replaced the risk derivation in `assess_trap_diffuseness` so `base_strength = max(trap_eval_minus_bulk, 0.0) / (abs(mp_bulk_max) + eps)` and `trap_risk_score = clip(base_strength * (1 - diffuseness_score), 0.0, 1.0)` while leaving the existing `trap_diffuseness_score` calculation unchanged. 
- Updated the `trap_assessment` branching to use the new risk-first logic: `localized_risky` when `trap_risk_score >= 0.50`, `benign_diffuse` when `trap_diffuseness_score >= 0.55`, and `mixed` otherwise. 
- Preserved returned dict keys exactly (`"trap_diffuseness_score"`, `"trap_risk_score"`, `"trap_assessment"`) and kept API/CSV/plot column names unchanged. 
- Clarified the function docstring to reflect the new diffuse-corrected interpretation of risk and added unit tests exercising the new behavior.

### Testing
- Added tests in `tests/test_trap_diffuseness.py` that verify monotonic decrease of `trap_risk_score` with increasing diffuseness, edge cases where diffuseness is `1.0` (risk `0.0`) and `0.0` (risk equals clipped base strength), and the original output key contract. 
- Ran `pytest -q tests/test_trap_diffuseness.py tests/test_analyze_traps.py` and observed `5 passed, 11 skipped`, indicating the changes meet the automated test expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d98815ab4083208b3e01bbdf30f04d)