### PR TITLE
docs: add trap workflow guide for analyze_traps/remove_traps

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ New in v0.8.0: trap-level randomized diagnostics:
 trap_df = watcher.analyze_traps(layers=[3, 5], plot=True, savefig="trap_images")
 ```
 
+See the new usage guide: [Correlation Trap Workflow (`analyze_traps` + `remove_traps`)](./docs_trap_features.md)
+
 ## PEFT / LORA models  (experimental)
 To analyze an PEFT / LORA fine-tuned model, specify the peft option.
 
@@ -286,6 +288,8 @@ Trap analysis example:
 watcher = ww.WeightWatcher(model=my_model)
 trap_df = watcher.analyze_traps(layers=[3, 5], plot=True, savefig="trap_images")
 ```
+
+For a complete walkthrough (including `remove_traps`), see: [Correlation Trap Workflow (`analyze_traps` + `remove_traps`)](./docs_trap_features.md)
 
 Fig (a) is well trained; Fig (b) may be over-fit.
 	

--- a/docs_trap_features.md
+++ b/docs_trap_features.md
@@ -1,0 +1,91 @@
+# Correlation Trap Workflow (`analyze_traps` and `remove_traps`)
+
+This guide explains how to use the new correlation-trap workflow that was recently merged into WeightWatcher.
+
+> ⚠️ **Status note:** these features were **vibe coded** and are **not yet extensively tested**. Please validate outputs on your own models and use caution before applying them in production pipelines.
+
+## What these features do
+
+- `analyze_traps(...)` inspects selected layers and reports candidate correlation-trap modes.
+- `remove_traps(...)` removes selected trap modes from those layers and returns an updated model.
+
+Use this flow when you suspect a layer looks random except for isolated spikes (classic trap signature).
+
+## 1) Analyze trap candidates
+
+```python
+import weightwatcher as ww
+import torchvision.models as models
+
+model = models.vgg19_bn(pretrained=True)
+watcher = ww.WeightWatcher(model=model)
+
+trap_df = watcher.analyze_traps(
+    layers=[3, 5],
+    plot=True,
+    savefig="trap_images",
+    rng=123,
+)
+
+print(trap_df[["layer_id", "layer_name", "num_traps"]])
+```
+
+### Tips
+
+- Start with a small set of layers (`layers=[...]`) you already flagged with `analyze(randomize=True)`.
+- Set a fixed `rng` (int seed) for reproducibility.
+- Use `plot=True` + `savefig=...` to inspect before/after spectra artifacts.
+
+## 2) Remove selected trap indices
+
+After identifying trap indices of interest, run:
+
+```python
+clean_model = watcher.remove_traps(
+    model=model,
+    layers=[3, 5],
+    trap_indices=[1],
+    seed=123,
+    pool=True,
+    plot=False,
+)
+```
+
+### Important behavior
+
+- `trap_indices` are **1-based trap IDs** reported by the trap analysis flow.
+- Current implementation is focused on supported layer/matrix paths used by the merged feature tests.
+- Always compare metrics before and after (`analyze`, `get_summary`, eval task metrics).
+
+## 3) Recommended validation checklist
+
+Because this workflow is new and still stabilizing:
+
+1. Save baseline model metrics and downstream task scores.
+2. Run `analyze_traps(...)` with a fixed seed and inspect plots.
+3. Remove one trap at a time first (`trap_indices=[1]`, then iterate).
+4. Re-run WeightWatcher metrics and downstream evaluation.
+5. Keep a rollback path (checkpointed original model).
+
+## Minimal end-to-end sketch
+
+```python
+watcher = ww.WeightWatcher(model=model)
+
+# Baseline
+baseline_details = watcher.analyze(plot=False)
+baseline_summary = watcher.get_summary(baseline_details)
+
+# Trap diagnostics
+trap_df = watcher.analyze_traps(layers=[3, 5], rng=123, plot=True, savefig="trap_images")
+
+# Trap removal (example: first detected trap mode)
+clean_model = watcher.remove_traps(model=model, layers=[3, 5], trap_indices=[1], seed=123)
+
+# Re-check
+clean_watcher = ww.WeightWatcher(model=clean_model)
+clean_details = clean_watcher.analyze(plot=False)
+clean_summary = clean_watcher.get_summary(clean_details)
+```
+
+If you find edge cases, please open an issue with model type, layer selection, and seed used.


### PR DESCRIPTION
### Motivation
- Document the recently merged correlation-trap workflow (`analyze_traps` / `remove_traps`) and surface usage guidance and caveats because the features were vibe coded and are not yet extensively tested.

### Description
- Add `docs_trap_features.md` with example snippets, recommended validation steps, and an explicit status note, and update `README.md` to link to the new subpage from the trap diagnostics and correlation-traps sections.

### Testing
- Ran targeted tests `pytest -q tests/test_analyze_traps.py tests/test_remove_traps.py` which resulted in 2 failures and 2 passes with 16 skipped; the failures are in `tests/test_remove_traps.py` and are due to `rng`/`seed` argument handling in the remove-traps code path, and no code behavior was changed in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd74070dfc8320ac50036820615497)