### PR TITLE
Enable trap histogram plotting by default and add histogram utilities/tests

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1]
+Enabled trap histogram plots by default in `analyze_traps(...)` and `remove_traps(...)`
+Added shared trap histogram overlays with dashed per-trap vertical lines and consistent severity-aware color mapping
+
 ## [0.8.0]
 Added `analyze_traps(...)` for randomized correlation-trap analysis
 Added per-trap vector and order-invariant trap metrics

--- a/tests/test_trap_histograms.py
+++ b/tests/test_trap_histograms.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from weightwatcher.trap_histograms import _largest_trap_elements, _trap_color
+
+
+def test_largest_trap_elements_single_peak():
+    T = np.array([[0.1, -0.2], [0.4, -3.0]])
+    vals = _largest_trap_elements(T)
+    assert vals.shape == (1,)
+    assert np.isclose(vals[0], -3.0)
+
+
+def test_largest_trap_elements_multiple_peaks():
+    T = np.array([[1.0, -2.5], [2.5, -0.1]])
+    vals = np.sort(_largest_trap_elements(T))
+    assert vals.shape == (2,)
+    assert np.allclose(vals, np.array([-2.5, 2.5]))
+
+
+def test_trap_color_varies_by_assessment():
+    mixed = _trap_color(1, "mixed")
+    risky = _trap_color(1, "localized_risky")
+    benign = _trap_color(1, "benign_diffuse")
+
+    assert len(mixed) == 3
+    assert len(risky) == 3
+    assert len(benign) == 3
+
+    # risky should be darker than mixed; benign should be lighter than mixed.
+    assert np.mean(risky) < np.mean(mixed)
+    assert np.mean(benign) > np.mean(mixed)

--- a/weightwatcher/__init__.py
+++ b/weightwatcher/__init__.py
@@ -19,7 +19,7 @@ from .weightwatcher import WeightWatcher
 
 __name__ = "weightwatcher"
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 
 __license__ = "Apache License, Version 2.0"
 __description__ = "Diagnostic Tool for Deep Neural Networks"

--- a/weightwatcher/remove_traps.py
+++ b/weightwatcher/remove_traps.py
@@ -6,6 +6,7 @@ from .RMT_Util import svd_full, unpermute_matrix
 from .constants import DEFAULT_PARAMS, DEFAULT_START_ID, FAST_SVD, LAYER_TYPE, PEFT, PLOT, POOL, START_IDS, SVD_METHOD, DEFAULT_PEFT
 from .constants import LAYERS
 from .constants import WW_NAME
+from .trap_histograms import plot_layer_trap_weight_histogram
 
 logger = logging.getLogger(WW_NAME)
 
@@ -168,6 +169,34 @@ def apply_remove_traps(ww, ww_layer, trap_indices, params=None, seed=None, rng=N
         return ww_layer
     requested = valid_indices
 
+    if params.get(PLOT, False):
+        max_sigma = max(float(a.get("sigma_perm", 0.0)) for a in artifacts) if len(artifacts) > 0 else 0.0
+        trap_infos = []
+        for idx in requested:
+            artifact = artifacts[idx - 1]
+            rel_sigma = float(artifact.get("sigma_perm", 0.0)) / (max_sigma + 1e-12)
+            if rel_sigma >= 0.8:
+                assessment = "localized_risky"
+            elif rel_sigma <= 0.35:
+                assessment = "benign_diffuse"
+            else:
+                assessment = "mixed"
+            trap_infos.append(
+                {
+                    "trap_index": idx,
+                    "trap_matrix": artifact["T_orig_raw"],
+                    "trap_assessment": assessment,
+                    "trap_risk_score": rel_sigma,
+                }
+            )
+
+        plot_layer_trap_weight_histogram(
+            ww_layer,
+            trap_infos,
+            params=params,
+            method_tag="remove_traps",
+        )
+
     old_W = ww_layer.Wmats[0]
     new_W = old_W.copy()
     for idx in requested:
@@ -180,7 +209,7 @@ def apply_remove_traps(ww, ww_layer, trap_indices, params=None, seed=None, rng=N
     return ww_layer
 
 
-def remove_traps(ww, model=None, layers=[], trap_indices=None, seed=None, rng=None, pool=True, plot=False,
+def remove_traps(ww, model=None, layers=[], trap_indices=None, seed=None, rng=None, pool=True, plot=True,
                  start_ids=DEFAULT_START_ID, svd_method=FAST_SVD, base_model=None, peft=DEFAULT_PEFT):
     if trap_indices is None or len(trap_indices) == 0:
         raise ValueError("trap_indices must be provided and non-empty")

--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from . import remove_traps as remove_traps_ops
 from . import weightwatcher as wwcore
+from .trap_histograms import plot_layer_trap_weight_histogram
 
 
 def analyze_traps(
@@ -14,7 +15,7 @@ def analyze_traps(
     max_size=None,
     max_N=wwcore.DEFAULT_MAX_N,
     glorot_fix=False,
-    plot=False,
+    plot=True,
     savefig=wwcore.DEF_SAVE_DIR,
     conv2d_norm=True,
     ww2x=wwcore.DEFAULT_WW2X,
@@ -92,6 +93,37 @@ def analyze_traps(
             layer_rows = watcher.apply_analyze_traps(ww_layer, params=params)
             if layer_rows:
                 trap_rows.extend(layer_rows)
+
+                if params.get(wwcore.PLOT, False):
+                    artifacts = remove_traps_ops.collect_trap_artifacts(
+                        watcher,
+                        ww_layer,
+                        params=params,
+                        rng=params.get("rng", None),
+                    )
+                    rows_by_trap_index = {
+                        int(row.get("trap_index", -1)) + 1: row
+                        for row in layer_rows
+                        if row.get("trap_index", None) is not None
+                    }
+                    trap_infos = []
+                    for artifact in artifacts:
+                        trap_idx = int(artifact["trap_index"])
+                        row = rows_by_trap_index.get(trap_idx, {})
+                        trap_infos.append(
+                            {
+                                "trap_index": trap_idx,
+                                "trap_matrix": artifact["T_orig_raw"],
+                                "trap_assessment": row.get("trap_assessment", "mixed"),
+                                "trap_risk_score": row.get("trap_risk_score", 0.0),
+                            }
+                        )
+                    plot_layer_trap_weight_histogram(
+                        ww_layer,
+                        trap_infos,
+                        params=params,
+                        method_tag="analyze_traps",
+                    )
 
     if len(trap_rows) > 0:
         details = pd.DataFrame.from_records(trap_rows)

--- a/weightwatcher/trap_histograms.py
+++ b/weightwatcher/trap_histograms.py
@@ -1,0 +1,139 @@
+import logging
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .RMT_Util import save_fig
+from .constants import SAVEFIG, SAVEDIR, WW_NAME
+
+logger = logging.getLogger(WW_NAME)
+
+
+def _resolve_trap_assessment(trap_info):
+    assessment = trap_info.get("trap_assessment", None)
+    if assessment is not None:
+        return assessment
+
+    risk_score = float(trap_info.get("trap_risk_score", 0.0))
+    if risk_score >= 0.5:
+        return "localized_risky"
+    if risk_score <= 0.2:
+        return "benign_diffuse"
+    return "mixed"
+
+
+def _adjust_color_towards_white(color, amount):
+    rgb = np.array(color[:3], dtype=float)
+    adjusted = rgb + (1.0 - rgb) * float(np.clip(amount, 0.0, 1.0))
+    return tuple(np.clip(adjusted, 0.0, 1.0))
+
+
+def _adjust_color_towards_black(color, amount):
+    rgb = np.array(color[:3], dtype=float)
+    adjusted = rgb * (1.0 - float(np.clip(amount, 0.0, 1.0)))
+    return tuple(np.clip(adjusted, 0.0, 1.0))
+
+
+def _trap_color(trap_index, assessment):
+    cmap = plt.get_cmap("tab20")
+    base = cmap((trap_index - 1) % 20)
+
+    if assessment == "localized_risky":
+        return _adjust_color_towards_black(base, 0.25)
+    if assessment == "benign_diffuse":
+        return _adjust_color_towards_white(base, 0.35)
+    return base[:3]
+
+
+def _largest_trap_elements(trap_matrix, atol=1e-12):
+    abs_vals = np.abs(trap_matrix)
+    if abs_vals.size == 0:
+        return np.array([], dtype=float)
+
+    max_abs = np.max(abs_vals)
+    if max_abs <= 0.0:
+        return np.array([], dtype=float)
+
+    mask = np.isclose(abs_vals, max_abs, atol=atol, rtol=0.0)
+    return trap_matrix[mask]
+
+
+def plot_layer_trap_weight_histogram(ww_layer, trap_infos, params=None, method_tag="analyze_traps"):
+    """Plot per-layer weight histograms with dashed vertical trap marker lines.
+
+    Parameters
+    ----------
+    ww_layer : WWLayer
+        Layer to plot.
+    trap_infos : list[dict]
+        Each dict should include `trap_index`, `trap_matrix` and optionally
+        `trap_assessment` / `trap_risk_score`.
+    params : dict
+        WeightWatcher parameter dictionary.
+    method_tag : str
+        Method name included in titles and save-file labels.
+    """
+
+    if trap_infos is None or len(trap_infos) == 0:
+        return
+
+    if len(ww_layer.Wmats) == 0:
+        return
+
+    weights = ww_layer.Wmats[0]
+    if weights is None:
+        return
+
+    flat_weights = np.asarray(weights, dtype=float).ravel()
+    if flat_weights.size == 0:
+        return
+
+    layer_label = f"Layer {ww_layer.layer_id}"
+    if getattr(ww_layer, "name", None):
+        layer_label = f"{layer_label} ({ww_layer.name})"
+
+    fig, ax = plt.subplots(figsize=(9, 6))
+    ax.hist(flat_weights, bins=100, density=True, alpha=0.55, color="steelblue")
+
+    drawn_labels = set()
+    for trap_info in trap_infos:
+        trap_index = int(trap_info["trap_index"])
+        assessment = _resolve_trap_assessment(trap_info)
+        line_color = _trap_color(trap_index, assessment)
+
+        peak_values = np.asarray(_largest_trap_elements(np.asarray(trap_info["trap_matrix"], dtype=float))).ravel()
+        if peak_values.size == 0:
+            continue
+
+        peak_values = np.unique(np.round(peak_values.astype(float), 12))
+        for value in peak_values:
+            label = None
+            if trap_index not in drawn_labels:
+                label = f"trap {trap_index}"
+                drawn_labels.add(trap_index)
+
+            ax.axvline(
+                x=float(value),
+                color=line_color,
+                linestyle="--",
+                linewidth=1.6,
+                alpha=0.95,
+                label=label,
+            )
+
+    ax.set_xlabel("Weight value")
+    ax.set_ylabel("Density")
+    ax.set_title(f"{layer_label} — {method_tag} trap lines on weight histogram")
+    if len(drawn_labels) > 0:
+        ax.legend(loc="best", fontsize=8)
+
+    if params is None:
+        params = {}
+
+    if params.get(SAVEFIG, False):
+        savedir = params.get(SAVEDIR, "ww-img")
+        save_fig(plt, f"{method_tag}.trap_hist", ww_layer.plot_id, savedir)
+    else:
+        plt.tight_layout()
+
+    plt.close(fig)

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3697,7 +3697,7 @@ class WeightWatcher:
                 min_evals=DEFAULT_MIN_EVALS, max_evals=DEFAULT_MAX_EVALS,
                 min_size=None, max_size=None, max_N=DEFAULT_MAX_N,
                 glorot_fix=False,
-                plot=False, savefig=DEF_SAVE_DIR,
+                plot=True, savefig=DEF_SAVE_DIR,
                 conv2d_norm=True,
                 ww2x=DEFAULT_WW2X, pool=DEFAULT_POOL,
                 conv2d_fft=False, fft=False, channels=None,
@@ -5657,7 +5657,7 @@ class WeightWatcher:
         """Remove selected traps from one dense WWLayer and replace with matched random matrices."""
         return remove_traps_ops.apply_remove_traps(self, ww_layer, trap_indices, params=params, seed=seed, rng=rng)
 
-    def remove_traps(self, model=None, layers=[], trap_indices=None, seed=None, rng=None, pool=True, plot=False,
+    def remove_traps(self, model=None, layers=[], trap_indices=None, seed=None, rng=None, pool=True, plot=True,
                      start_ids=DEFAULT_START_ID, svd_method=FAST_SVD, base_model=None, peft=DEFAULT_PEFT):
         """Remove selected randomized MP/TW traps from dense layers."""
         return remove_traps_ops.remove_traps(


### PR DESCRIPTION
### Motivation

- Make trap-weight histograms easier to inspect by enabling automatic plotting when running `analyze_traps(...)` and `remove_traps(...)`.
- Provide a reusable plotting utility with consistent per-trap color mapping and visible dashed markers for trap peaks.

### Description

- Added a new module `weightwatcher/trap_histograms.py` implementing `plot_layer_trap_weight_histogram`, `_trap_color`, and `_largest_trap_elements` with assessment-aware coloring and peak-line overlays. 
- Integrates histogram plotting into `analyze_traps` and `remove_traps` by calling `plot_layer_trap_weight_histogram` and assembling `trap_infos` (the plotting defaults were changed to `plot=True`).
- Added unit tests in `tests/test_trap_histograms.py` to validate `_largest_trap_elements` and `_trap_color` behavior. 
- Bumped package version to `0.8.1` and updated `Changelog.txt` to document the change.

### Testing

- Added `tests/test_trap_histograms.py` which exercises `_largest_trap_elements` and `_trap_color` and was executed via `pytest`; the tests passed.
- Ran the updated unit tests including the new histogram tests as part of the local test run; all automated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dda0cfdf108320a6cc6ca6af3d7d75)