### PR TITLE
Format trap histogram labels, add min/max indicators, avoid persisting trap matrices when not plotting, and bump version

### DIFF
--- a/tests/test_trap_histograms.py
+++ b/tests/test_trap_histograms.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from weightwatcher.trap_histograms import _largest_trap_elements, _trap_color
+from weightwatcher.trap_histograms import _format_hist_value_label, _largest_trap_elements, _trap_color
 
 
 def test_largest_trap_elements_single_peak():
@@ -29,3 +29,8 @@ def test_trap_color_varies_by_assessment():
     # risky should be darker than mixed; benign should be lighter than mixed.
     assert np.mean(risky) < np.mean(mixed)
     assert np.mean(benign) > np.mean(mixed)
+
+
+def test_format_hist_value_label_compact_precision():
+    assert _format_hist_value_label(0.123456) == "0.1235"
+    assert _format_hist_value_label(12.3456) == "12.35"

--- a/weightwatcher/__init__.py
+++ b/weightwatcher/__init__.py
@@ -19,7 +19,7 @@ from .weightwatcher import WeightWatcher
 
 __name__ = "weightwatcher"
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 
 __license__ = "Apache License, Version 2.0"
 __description__ = "Diagnostic Tool for Deep Neural Networks"
@@ -30,5 +30,4 @@ __copyright__ = "Calculation Consulting"
 
 __all__ = ["__name__", "__version__", "__license__", "__description__",
           "__url__", "__author__", "__email__", "__copyright__"]
-
 

--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -90,40 +90,37 @@ def analyze_traps(
             if params[wwcore.FFT]:
                 watcher.apply_FFT(ww_layer, params)
 
-            layer_rows = watcher.apply_analyze_traps(ww_layer, params=params)
+            layer_params = dict(params)
+            layer_params["_keep_trap_matrix"] = bool(params.get(wwcore.PLOT, False))
+            layer_rows = watcher.apply_analyze_traps(ww_layer, params=layer_params)
             if layer_rows:
-                trap_rows.extend(layer_rows)
-
                 if params.get(wwcore.PLOT, False):
-                    artifacts = remove_traps_ops.collect_trap_artifacts(
-                        watcher,
-                        ww_layer,
-                        params=params,
-                        rng=params.get("rng", None),
-                    )
-                    rows_by_trap_index = {
-                        int(row.get("trap_index", -1)) + 1: row
-                        for row in layer_rows
-                        if row.get("trap_index", None) is not None
-                    }
                     trap_infos = []
-                    for artifact in artifacts:
-                        trap_idx = int(artifact["trap_index"])
-                        row = rows_by_trap_index.get(trap_idx, {})
+                    for row in layer_rows:
+                        trap_idx_zero_based = int(row.get("trap_index", -1))
+                        trap_matrix = row.get("T_orig", None)
+                        if trap_idx_zero_based < 0 or trap_matrix is None:
+                            continue
+
                         trap_infos.append(
                             {
-                                "trap_index": trap_idx,
-                                "trap_matrix": artifact["T_orig_raw"],
+                                "trap_index": trap_idx_zero_based + 1,
+                                "trap_matrix": trap_matrix,
                                 "trap_assessment": row.get("trap_assessment", "mixed"),
                                 "trap_risk_score": row.get("trap_risk_score", 0.0),
                             }
                         )
+
                     plot_layer_trap_weight_histogram(
                         ww_layer,
                         trap_infos,
                         params=params,
                         method_tag="analyze_traps",
                     )
+
+                for row in layer_rows:
+                    row.pop("T_orig", None)
+                trap_rows.extend(layer_rows)
 
     if len(trap_rows) > 0:
         details = pd.DataFrame.from_records(trap_rows)

--- a/weightwatcher/trap_histograms.py
+++ b/weightwatcher/trap_histograms.py
@@ -58,6 +58,10 @@ def _largest_trap_elements(trap_matrix, atol=1e-12):
     return trap_matrix[mask]
 
 
+def _format_hist_value_label(value):
+    return f"{float(value):.4g}"
+
+
 def plot_layer_trap_weight_histogram(ww_layer, trap_infos, params=None, method_tag="analyze_traps"):
     """Plot per-layer weight histograms with dashed vertical trap marker lines.
 
@@ -94,8 +98,22 @@ def plot_layer_trap_weight_histogram(ww_layer, trap_infos, params=None, method_t
 
     fig, ax = plt.subplots(figsize=(9, 6))
     ax.hist(flat_weights, bins=100, density=True, alpha=0.55, color="steelblue")
+    y_max = float(ax.get_ylim()[1])
+
+    min_w = float(np.min(flat_weights))
+    max_w = float(np.max(flat_weights))
+    indicator_height = max(y_max * 0.08, 1e-12)
+    ax.vlines(
+        [min_w, max_w],
+        ymin=0.0,
+        ymax=indicator_height,
+        colors="black",
+        linewidth=1.4,
+        alpha=0.85,
+    )
 
     drawn_labels = set()
+    trap_label_count = 0
     for trap_info in trap_infos:
         trap_index = int(trap_info["trap_index"])
         assessment = _resolve_trap_assessment(trap_info)
@@ -120,6 +138,19 @@ def plot_layer_trap_weight_histogram(ww_layer, trap_infos, params=None, method_t
                 alpha=0.95,
                 label=label,
             )
+            text_y = y_max * max(0.42, 0.98 - 0.07 * (trap_label_count % 7))
+            ax.text(
+                float(value),
+                text_y,
+                _format_hist_value_label(value),
+                color=line_color,
+                rotation=90,
+                va="top",
+                ha="right",
+                fontsize=7,
+                alpha=0.95,
+            )
+            trap_label_count += 1
 
     ax.set_xlabel("Weight value")
     ax.set_ylabel("Density")

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3938,7 +3938,8 @@ class WeightWatcher:
         trap_result.pop("right_overlaps", None)
         trap_result.pop("u_trap", None)
         trap_result.pop("v_trap", None)
-        trap_result.pop("T_orig", None)
+        if not params.get("_keep_trap_matrix", False):
+            trap_result.pop("T_orig", None)
         trap_result.pop("perm_evals_sorted", None)
 
         return trap_result


### PR DESCRIPTION
### Motivation
- Improve the readability of trap marker labels on per-layer weight histograms and avoid retaining large trap matrices in results unless needed for plotting.
- Make trap histogram plotting more informative by marking min/max weight indicators and positioning value labels to avoid overlap.

### Description
- Added `_format_hist_value_label` to format numeric labels compactly and used it to annotate trap marker lines on histograms.
- Enhanced `plot_layer_trap_weight_histogram` to draw min/max vertical indicators, compute `y_max` for label placement, and stagger label y-positions to reduce overlap while coloring labels by trap assessment.
- Changed trap-analysis flow so `T_orig` (the trap matrix) is preserved only when plotting is requested by introducing a `_keep_trap_matrix` flag propagated from `analyze_traps` to `apply_analyze_traps`, and removed `T_orig` from returned rows when not needed to reduce memory retained in `watcher.details`.
- Reworked how `trap_infos` are assembled for plotting by building them directly from `layer_rows` rather than collecting separate artifacts.
- Bumped package version from `0.8.1` to `0.8.2`.
- Added unit tests for the new label formatting function and imported it into the histogram test module.

### Testing
- Ran the histogram unit tests in `tests/test_trap_histograms.py` (including the new `_format_hist_value_label` assertions) via `pytest` and they passed.
- Ran the full test suite with `pytest -q` to validate integration of changes and the run completed with all tests passing.
- Verified that plotting-related code paths exercise the `_keep_trap_matrix` logic in unit/integration runs and did not retain `T_orig` when plotting was disabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddcb9345048320ad283b5cc6742409)