### PR TITLE
Summarize top trap components and improve trap-histogram plotting/utilities

### DIFF
--- a/tests/test_trap_component_summary.py
+++ b/tests/test_trap_component_summary.py
@@ -1,0 +1,35 @@
+import numpy as np
+
+from weightwatcher.trap_analysis import _top_trap_component_row
+
+
+def test_top_trap_component_row_extracts_top_10_weight_and_coeff_pairs():
+    trap = np.array(
+        [
+            [0.1, -0.9, 0.3],
+            [0.5, 0.2, -0.4],
+        ]
+    )
+    weights = np.array(
+        [
+            [11.0, 12.0, 13.0],
+            [21.0, 22.0, 23.0],
+        ]
+    )
+    row = {
+        "layer_id": 7,
+        "name": "dense",
+        "trap_index": 0,
+        "trap_assessment": "mixed",
+        "trap_risk_score": 0.4,
+        "T_orig": trap,
+    }
+
+    out = _top_trap_component_row(row=row, weight_matrix=weights, top_k=3)
+
+    assert out["layer_id"] == 7
+    assert out["trap_index"] == 1
+    assert np.isclose(out["Wij_1"], 12.0)  # |coeff| = 0.9, largest
+    assert np.isclose(out["Cij_1"], -1.0)  # normalized by max |coeff|
+    assert np.isclose(out["Wij_2"], 21.0)  # |coeff| = 0.5
+    assert np.isclose(out["Cij_2"], 0.5 / 0.9)

--- a/tests/test_trap_histograms.py
+++ b/tests/test_trap_histograms.py
@@ -1,6 +1,12 @@
 import numpy as np
 
-from weightwatcher.trap_histograms import _format_hist_value_label, _largest_trap_elements, _trap_color
+from weightwatcher.trap_histograms import (
+    _format_hist_value_label,
+    _largest_trap_elements,
+    _largest_trap_weight_values,
+    _significant_trap_components,
+    _trap_color,
+)
 
 
 def test_largest_trap_elements_single_peak():
@@ -15,6 +21,42 @@ def test_largest_trap_elements_multiple_peaks():
     vals = np.sort(_largest_trap_elements(T))
     assert vals.shape == (2,)
     assert np.allclose(vals, np.array([-2.5, 2.5]))
+
+
+def test_largest_trap_weight_values_uses_weight_entries_at_peak_locations():
+    T = np.array([[0.1, -0.2], [0.4, -3.0]])
+    W = np.array([[0.1, -0.2], [0.4, -0.8]])
+    vals = _largest_trap_weight_values(T, W)
+    assert vals.shape == (1,)
+    assert np.isclose(vals[0], -0.8)
+
+
+def test_largest_trap_weight_values_falls_back_on_shape_mismatch():
+    T = np.array([[1.0, -2.5], [2.5, -0.1]])
+    W = np.array([1.0, 2.0, 3.0])
+    vals = np.sort(_largest_trap_weight_values(T, W))
+    assert vals.shape == (2,)
+    assert np.allclose(vals, np.array([-2.5, 2.5]))
+
+
+def test_rank1_component_entry_can_exceed_observed_weight_entry():
+    # W is the sum of components; cancellation can keep W entries small even when
+    # a single component has a larger-magnitude value at the same index.
+    trap_component = np.array([[2.0, 0.0], [0.0, 0.0]])
+    cancelling_component = np.array([[-1.7, 0.0], [0.0, 0.0]])
+    W = trap_component + cancelling_component
+
+    assert np.max(np.abs(trap_component)) > np.max(np.abs(W))
+
+
+def test_significant_trap_components_filters_by_relative_threshold():
+    T = np.array([[1.0, 0.2], [0.31, -0.05]])
+    W = np.array([[10.0, 20.0], [30.0, 40.0]])
+    x_vals, rel_vals, signed = _significant_trap_components(T, W, min_rel_coeff=0.3)
+
+    assert np.allclose(np.sort(x_vals), np.array([10.0, 30.0]))
+    assert np.all(rel_vals >= 0.3)
+    assert signed.shape == x_vals.shape
 
 
 def test_trap_color_varies_by_assessment():

--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import numpy as np
 
 from . import remove_traps as remove_traps_ops
 from . import weightwatcher as wwcore
@@ -82,6 +83,7 @@ def analyze_traps(
 
     layer_iterator = watcher.make_layer_iterator(model=watcher.model, layers=layers, params=params, base_model=watcher.base_model)
     trap_rows = []
+    trap_component_rows = []
 
     for ww_layer in layer_iterator:
         if not ww_layer.skipped and ww_layer.has_weights:
@@ -110,6 +112,13 @@ def analyze_traps(
                                 "trap_risk_score": row.get("trap_risk_score", 0.0),
                             }
                         )
+                        trap_component_rows.append(
+                            _top_trap_component_row(
+                                row=row,
+                                weight_matrix=ww_layer.Wmats[0],
+                                top_k=10,
+                            )
+                        )
 
                     plot_layer_trap_weight_histogram(
                         ww_layer,
@@ -135,4 +144,50 @@ def analyze_traps(
         details = details[lead_cols + [c for c in details.columns if c not in lead_cols]]
 
     watcher.details = details
+
+    if len(trap_component_rows) > 0:
+        trap_component_df = pd.DataFrame.from_records(trap_component_rows)
+        fixed_cols = ["layer_id", "name", "trap_index", "trap_assessment", "trap_risk_score"]
+        pair_cols = [col for i in range(1, 11) for col in (f"Wij_{i}", f"Cij_{i}")]
+        ordered_cols = [c for c in (fixed_cols + pair_cols) if c in trap_component_df.columns]
+        trap_component_df = trap_component_df.reindex(columns=ordered_cols)
+        watcher.trap_component_summary = trap_component_df
+        print(trap_component_df.to_string(index=False))
+    else:
+        watcher.trap_component_summary = pd.DataFrame()
+
     return details
+
+
+def _top_trap_component_row(row, weight_matrix, top_k=10):
+    trap_matrix = np.asarray(row.get("T_orig", np.array([])), dtype=float)
+    weight_matrix = np.asarray(weight_matrix, dtype=float)
+
+    out = {
+        "layer_id": row.get("layer_id"),
+        "name": row.get("name"),
+        "trap_index": int(row.get("trap_index", -1)) + 1,
+        "trap_assessment": row.get("trap_assessment", "mixed"),
+        "trap_risk_score": float(row.get("trap_risk_score", 0.0)),
+    }
+
+    for i in range(1, top_k + 1):
+        out[f"Wij_{i}"] = np.nan
+        out[f"Cij_{i}"] = np.nan
+
+    if trap_matrix.size == 0 or trap_matrix.shape != weight_matrix.shape:
+        return out
+
+    flat_trap = trap_matrix.ravel()
+    flat_weight = weight_matrix.ravel()
+    abs_coeff = np.abs(flat_trap)
+    max_abs = float(np.max(abs_coeff)) if abs_coeff.size else 0.0
+    if max_abs <= 0.0:
+        return out
+
+    order = np.argsort(abs_coeff)[::-1][:top_k]
+    for rank, idx in enumerate(order, start=1):
+        out[f"Wij_{rank}"] = float(flat_weight[idx])
+        out[f"Cij_{rank}"] = float(flat_trap[idx] / max_abs)
+
+    return out

--- a/weightwatcher/trap_histograms.py
+++ b/weightwatcher/trap_histograms.py
@@ -46,6 +46,12 @@ def _trap_color(trap_index, assessment):
 
 
 def _largest_trap_elements(trap_matrix, atol=1e-12):
+    """Return entries of a trap component at its max-|value| locations.
+
+    Note: a rank-1 trap component is only one additive term in the full matrix
+    decomposition. Its entries can exceed the observed min/max of W because
+    other components can cancel it when summed back into W.
+    """
     abs_vals = np.abs(trap_matrix)
     if abs_vals.size == 0:
         return np.array([], dtype=float)
@@ -58,8 +64,58 @@ def _largest_trap_elements(trap_matrix, atol=1e-12):
     return trap_matrix[mask]
 
 
+def _largest_trap_weight_values(trap_matrix, weight_matrix, atol=1e-12):
+    """Map trap peak locations into the actual weight-matrix value space."""
+    trap_matrix = np.asarray(trap_matrix, dtype=float)
+    weight_matrix = np.asarray(weight_matrix, dtype=float)
+
+    if trap_matrix.shape != weight_matrix.shape:
+        return _largest_trap_elements(trap_matrix, atol=atol)
+
+    abs_vals = np.abs(trap_matrix)
+    if abs_vals.size == 0:
+        return np.array([], dtype=float)
+
+    max_abs = np.max(abs_vals)
+    if max_abs <= 0.0:
+        return np.array([], dtype=float)
+
+    mask = np.isclose(abs_vals, max_abs, atol=atol, rtol=0.0)
+    return weight_matrix[mask]
+
+
 def _format_hist_value_label(value):
     return f"{float(value):.4g}"
+
+
+def _significant_trap_components(trap_matrix, weight_matrix, min_rel_coeff=0.25, max_components=300):
+    trap_flat = np.asarray(trap_matrix, dtype=float).ravel()
+    weight_flat = np.asarray(weight_matrix, dtype=float).ravel()
+
+    if trap_flat.size == 0 or weight_flat.size == 0 or trap_flat.size != weight_flat.size:
+        return np.array([], dtype=float), np.array([], dtype=float), np.array([], dtype=float)
+
+    abs_coeff = np.abs(trap_flat)
+    max_abs = float(np.max(abs_coeff))
+    if max_abs <= 0.0:
+        return np.array([], dtype=float), np.array([], dtype=float), np.array([], dtype=float)
+
+    rel_coeff = abs_coeff / max_abs
+    mask = rel_coeff >= float(min_rel_coeff)
+    if not np.any(mask):
+        return np.array([], dtype=float), np.array([], dtype=float), np.array([], dtype=float)
+
+    x_vals = weight_flat[mask]
+    rel_vals = rel_coeff[mask]
+    signed_coeff = trap_flat[mask]
+
+    if x_vals.size > max_components:
+        order = np.argsort(rel_vals)[::-1][:max_components]
+        x_vals = x_vals[order]
+        rel_vals = rel_vals[order]
+        signed_coeff = signed_coeff[order]
+
+    return x_vals, rel_vals, signed_coeff
 
 
 def plot_layer_trap_weight_histogram(ww_layer, trap_infos, params=None, method_tag="analyze_traps"):
@@ -99,6 +155,7 @@ def plot_layer_trap_weight_histogram(ww_layer, trap_infos, params=None, method_t
     fig, ax = plt.subplots(figsize=(9, 6))
     ax.hist(flat_weights, bins=100, density=True, alpha=0.55, color="steelblue")
     y_max = float(ax.get_ylim()[1])
+    trap_bar_threshold = 0.30
 
     min_w = float(np.min(flat_weights))
     max_w = float(np.max(flat_weights))
@@ -119,38 +176,45 @@ def plot_layer_trap_weight_histogram(ww_layer, trap_infos, params=None, method_t
         assessment = _resolve_trap_assessment(trap_info)
         line_color = _trap_color(trap_index, assessment)
 
-        peak_values = np.asarray(_largest_trap_elements(np.asarray(trap_info["trap_matrix"], dtype=float))).ravel()
-        if peak_values.size == 0:
+        x_vals, rel_vals, signed_coeff = _significant_trap_components(
+            np.asarray(trap_info["trap_matrix"], dtype=float),
+            np.asarray(weights, dtype=float),
+            min_rel_coeff=trap_bar_threshold,
+        )
+        if x_vals.size == 0:
             continue
 
-        peak_values = np.unique(np.round(peak_values.astype(float), 12))
-        for value in peak_values:
-            label = None
-            if trap_index not in drawn_labels:
-                label = f"trap {trap_index}"
-                drawn_labels.add(trap_index)
+        label = None
+        if trap_index not in drawn_labels:
+            label = f"trap {trap_index}"
+            drawn_labels.add(trap_index)
 
-            ax.axvline(
-                x=float(value),
-                color=line_color,
-                linestyle="--",
-                linewidth=1.6,
-                alpha=0.95,
-                label=label,
-            )
-            text_y = y_max * max(0.42, 0.98 - 0.07 * (trap_label_count % 7))
-            ax.text(
-                float(value),
-                text_y,
-                _format_hist_value_label(value),
-                color=line_color,
-                rotation=90,
-                va="top",
-                ha="right",
-                fontsize=7,
-                alpha=0.95,
-            )
-            trap_label_count += 1
+        ax.vlines(
+            x_vals,
+            ymin=0.0,
+            ymax=rel_vals * y_max,
+            colors=[line_color],
+            linewidth=1.0,
+            alpha=0.35,
+            label=label,
+        )
+
+        top_idx = int(np.argmax(rel_vals))
+        top_x = float(x_vals[top_idx])
+        top_coeff = float(signed_coeff[top_idx])
+        text_y = y_max * max(0.42, 0.98 - 0.07 * (trap_label_count % 7))
+        ax.text(
+            top_x,
+            text_y,
+            _format_hist_value_label(top_coeff),
+            color=line_color,
+            rotation=90,
+            va="top",
+            ha="right",
+            fontsize=7,
+            alpha=0.95,
+        )
+        trap_label_count += 1
 
     ax.set_xlabel("Weight value")
     ax.set_ylabel("Density")


### PR DESCRIPTION
### Motivation
- Provide a per-layer summary of the strongest rank-1 trap components so users can inspect the top weight/coeff pairs for each detected trap. 
- Improve histogram plotting to mark significant trap component contributions using actual weight values and relative coefficient heights rather than only peak component values. 
- Add helpers to reliably map trap peak locations into the weight matrix and to filter significant component entries by relative coefficient magnitude.

### Description
- Added NumPy import and extended `analyze_traps` to collect `trap_component_rows` during plotting and expose a `watcher.trap_component_summary` DataFrame with ordered columns (`layer_id`, `name`, `trap_index`, `trap_assessment`, `trap_risk_score`, and up to `Wij_1..Wij_10`/`Cij_1..Cij_10`).
- Implemented `_top_trap_component_row` to extract top-k entries by absolute coefficient from a trap component and report the corresponding weight value and normalized coefficient.
- Enhanced `trap_histograms` with `_largest_trap_weight_values` and `_significant_trap_components` utilities and clarified `_largest_trap_elements` docstring.
- Updated `plot_layer_trap_weight_histogram` to draw vertical bars at significant weight positions with heights proportional to relative coefficient magnitude, label the top coefficient, use a `trap_bar_threshold`, and adjust label/legend logic.
- Added tests: `tests/test_trap_component_summary.py` for `_top_trap_component_row` and expanded `tests/test_trap_histograms.py` to cover `_largest_trap_weight_values` and `_significant_trap_components` behavior.

### Testing
- Ran the new and updated unit tests under `tests/` including `tests/test_trap_component_summary.py` and `tests/test_trap_histograms.py` with `pytest`, and all tests passed.
- Verified histogram plotting logic paths exercised by the histogram tests (no plotting output asserted), and the new component-extraction tests validated expected numeric outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddce156c9c8320af7b4116e7a34e18)