### PR TITLE
Add optional trap variance-burden metrics to analyze_traps

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,22 @@ trap_df = watcher.analyze_traps(layers=[3, 5], plot=True, savefig="trap_images")
 
 For a complete walkthrough (including `remove_traps`), see: [Correlation Trap Workflow (`analyze_traps` + `remove_traps`)](./docs_trap_features.md)
 
+#### Trap variance burden
+
+`analyze_traps` can optionally compute trap burden metrics with `trap_burden=True`.
+
+Two burden variants are available:
+
+- IPR version: `trap_variance_burden_ipr = spectral_excess_abs * ipr_lift_excess_pos * ov_lam_weighted_var`
+- Top5 version: `trap_variance_burden_top5 = spectral_excess_abs * log1p_top_5_lift * ov_rank_mean`
+
+Where:
+- `spectral_excess_abs` measures trap strength above the MP bulk edge.
+- `ipr_lift_excess_pos` measures localization relative to bulk modes.
+- `top_5_lift` measures concentration of the trap matrix relative to bulk modes.
+- `ov_lam_weighted_var` measures how broadly the trap overlaps eigenvalue scales of `X = W^T W`.
+- `ov_rank_mean` measures where the trap lives in the eigenbasis rank ordering of `X`.
+
 Fig (a) is well trained; Fig (b) may be over-fit.
 	
 That orange spike on the far right is the tell-tale clue; it's caled a **Correlation Trap**.  

--- a/tests/test_analyze_traps.py
+++ b/tests/test_analyze_traps.py
@@ -141,6 +141,43 @@ class TestAnalyzeTraps(unittest.TestCase):
         ]:
             self.assertTrue(np.isfinite(row[col]))
 
+    def test_analyze_traps_trap_burden_backward_compat(self):
+        df = self.watcher.analyze_traps(plot=False, savefig=False, trap_burden=False)
+        self.assertIsInstance(df, pd.DataFrame)
+        for col in ["top_5_mass", "bulk_top_5_mass_mean", "bulk_top_10_mass_mean"]:
+            self.assertIn(col, df.columns)
+
+    def test_analyze_traps_trap_burden_columns_appear(self):
+        df = self.watcher.analyze_traps(plot=False, savefig=False, trap_burden=True)
+        required = {
+            "spectral_excess_abs", "spectral_excess_rel", "trap_ipr", "bulk_ipr_mean",
+            "ipr_lift_excess_pos", "top_5_lift", "log1p_top_5_lift", "ov_lam_weighted_var",
+            "ov_rank_mean", "trap_variance_burden_ipr", "trap_variance_burden_top5", "trap_variance_burden",
+        }
+        self.assertTrue(required.issubset(set(df.columns)))
+
+    def test_analyze_traps_trap_burden_finite_values(self):
+        df = self.watcher.analyze_traps(plot=False, savefig=False, trap_burden=True)
+        if len(df) == 0:
+            self.skipTest("No traps detected in this environment")
+        finite_mask = np.isfinite(df["spectral_excess_abs"]) & np.isfinite(df["ov_lam_weighted_var"]) & np.isfinite(df["ov_rank_mean"]) & np.isfinite(df["trap_variance_burden"])
+        self.assertTrue(finite_mask.any())
+
+    def test_analyze_traps_trap_burden_variant_selection(self):
+        df_ipr = self.watcher.analyze_traps(plot=False, savefig=False, trap_burden=True, trap_burden_variant="ipr")
+        mask_ipr = np.isfinite(df_ipr["trap_variance_burden"]) & np.isfinite(df_ipr["trap_variance_burden_ipr"])
+        if mask_ipr.any():
+            self.assertTrue(np.allclose(df_ipr.loc[mask_ipr, "trap_variance_burden"], df_ipr.loc[mask_ipr, "trap_variance_burden_ipr"]))
+
+        df_top5 = self.watcher.analyze_traps(plot=False, savefig=False, trap_burden=True, trap_burden_variant="top5")
+        mask_top5 = np.isfinite(df_top5["trap_variance_burden"]) & np.isfinite(df_top5["trap_variance_burden_top5"])
+        if mask_top5.any():
+            self.assertTrue(np.allclose(df_top5.loc[mask_top5, "trap_variance_burden"], df_top5.loc[mask_top5, "trap_variance_burden_top5"]))
+
+    def test_analyze_traps_trap_burden_invalid_variant(self):
+        with self.assertRaises(ValueError):
+            self.watcher.analyze_traps(plot=False, savefig=False, trap_burden=True, trap_burden_variant="bad")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -29,6 +29,8 @@ def analyze_traps(
     base_model=None,
     peft=wwcore.DEFAULT_PEFT,
     rng=None,
+    trap_burden=False,
+    trap_burden_variant="top5",
 ):
     """Externalized implementation for WeightWatcher.analyze_traps()."""
     if layers is None:
@@ -73,6 +75,8 @@ def analyze_traps(
     params[wwcore.PEFT] = peft
     params[wwcore.INVERSE] = False
     params["rng"] = remove_traps_ops._normalize_trap_rng(rng=rng)
+    params["trap_burden"] = bool(trap_burden)
+    params["trap_burden_variant"] = trap_burden_variant
 
     wwcore.logger.debug("params {}".format(params))
     if not watcher.valid_params(params):

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3705,7 +3705,9 @@ class WeightWatcher:
                 start_ids=DEFAULT_START_ID,
                 base_model=None,
                 peft=DEFAULT_PEFT,
-                rng=None):
+                rng=None,
+                trap_burden=False,
+                trap_burden_variant="top5"):
         """Analyze randomized correlation traps and return one row per trap.
 
         This method follows the randomized/permuted trap workflow:
@@ -3750,6 +3752,8 @@ class WeightWatcher:
             base_model=base_model,
             peft=peft,
             rng=rng,
+            trap_burden=trap_burden,
+            trap_burden_variant=trap_burden_variant,
         )
 
     def _trap_result_columns(self):
@@ -3773,6 +3777,14 @@ class WeightWatcher:
             "v_top1_mass", "v_top5_mass", "v_top10_mass", "v_squared_amp_entropy", "v_stable_rank_surrogate",
             "trap_balance_ratio", "trap_detected", "trap_eval_minus_bulk",
             "trap_diffuseness_score", "trap_risk_score", "trap_assessment",
+            "spectral_excess_abs", "spectral_excess_rel",
+            "trap_ipr", "bulk_ipr_mean", "bulk_ipr_std",
+            "ipr_lift", "ipr_lift_excess_pos",
+            "top_5_lift", "top_5_lift_excess_pos", "log1p_top_5_lift",
+            "ov_lam_weighted_mean", "ov_lam_weighted_var",
+            "ov_rank_mean", "ov_rank_std",
+            "ov_hhi", "ov_participation", "ov_entropy", "ov_max",
+            "trap_variance_burden_ipr", "trap_variance_burden_top5", "trap_variance_burden",
         ]
 
 
@@ -3800,6 +3812,7 @@ class WeightWatcher:
                 original_basis_cache=original_basis_cache,
                 params=params,
                 trap_index=trap_index,
+                bulk_stats=bulk_stats,
             )
             trap_row.update(bulk_stats)
             trap_rows.append(trap_row)
@@ -3845,6 +3858,8 @@ class WeightWatcher:
                 "bulk_top_5_mass_std": np.nan,
                 "bulk_top_10_mass_mean": np.nan,
                 "bulk_top_10_mass_std": np.nan,
+                "bulk_ipr_mean": np.nan,
+                "bulk_ipr_std": np.nan,
             }
 
         W_perm = ww_layer.Wmats[0].astype(float)
@@ -3862,11 +3877,14 @@ class WeightWatcher:
                 "bulk_top_5_mass_std": np.nan,
                 "bulk_top_10_mass_mean": np.nan,
                 "bulk_top_10_mass_std": np.nan,
+                "bulk_ipr_mean": np.nan,
+                "bulk_ipr_std": np.nan,
             }
 
         bulk_localization = []
         bulk_top_5_mass = []
         bulk_top_10_mass = []
+        bulk_ipr = []
 
         for mode_idx in bulk_indices:
             u_mode = U_perm[:, mode_idx]
@@ -3880,9 +3898,13 @@ class WeightWatcher:
 
             T_perm = float(S_perm[mode_idx]) * np.outer(u_mode, v_mode)
             T_orig = unpermute_matrix(T_perm, p_ids)
+            Ut, _, Vht = svd_full(T_orig, method=params[SVD_METHOD])
+            u_trap = Ut[:, 0]
+            v_trap = Vht.T[:, 0]
             bulk_localization.append(loc)
             bulk_top_5_mass.append(self._top_percent_abs_mass(T_orig, 5.0))
             bulk_top_10_mass.append(self._top_percent_abs_mass(T_orig, 10.0))
+            bulk_ipr.append(0.5 * (float(np.sum(u_trap ** 4)) + float(np.sum(v_trap ** 4))))
 
         return {
             "bulk_mode_count": int(len(bulk_indices)),
@@ -3892,6 +3914,8 @@ class WeightWatcher:
             "bulk_top_5_mass_std": float(np.nanstd(bulk_top_5_mass)),
             "bulk_top_10_mass_mean": float(np.nanmean(bulk_top_10_mass)),
             "bulk_top_10_mass_std": float(np.nanstd(bulk_top_10_mass)),
+            "bulk_ipr_mean": float(np.nanmean(bulk_ipr)),
+            "bulk_ipr_std": float(np.nanstd(bulk_ipr)),
         }
 
 
@@ -3910,10 +3934,12 @@ class WeightWatcher:
         }
 
 
-    def analyze_single_trap(self, ww_layer, trap_mode_index, original_basis_cache=None, params=None, trap_index=0):
+    def analyze_single_trap(self, ww_layer, trap_mode_index, original_basis_cache=None, params=None, trap_index=0, bulk_stats=None):
         if params is None: params = DEFAULT_PARAMS.copy()
         if original_basis_cache is None:
             original_basis_cache = self.compute_original_basis_for_traps(ww_layer, params=params)
+        if bulk_stats is None:
+            bulk_stats = {}
 
         W_perm = ww_layer.Wmats[0].astype(float)
         p_ids = ww_layer.permute_ids[0]
@@ -3961,6 +3987,7 @@ class WeightWatcher:
         v_oi = self._trap_vector_order_invariant_stats(v_trap)
 
         eval_perm = sigma_perm ** 2
+        trap_ipr = 0.5 * (float(np.sum(u_trap ** 4)) + float(np.sum(v_trap ** 4)))
         trap_result = {
             "layer_id": ww_layer.layer_id,
             "name": ww_layer.name,
@@ -3993,6 +4020,95 @@ class WeightWatcher:
             "trap_detected": True,
             "trap_eval_minus_bulk": float(eval_perm - ww_layer.bulk_max),
         }
+        if params.get("trap_burden", False):
+            variant = params.get("trap_burden_variant", "top5")
+            if variant not in {"ipr", "top5", "both"}:
+                raise ValueError("trap_burden_variant must be one of {'ipr','top5','both'}")
+
+            mp_bulk_max = trap_result.get("mp_bulk_max", np.nan)
+            spectral_excess_abs = float(max(eval_perm - mp_bulk_max, 0.0)) if np.isfinite(mp_bulk_max) else np.nan
+            spectral_excess_rel = np.nan
+            if np.isfinite(mp_bulk_max) and mp_bulk_max != 0.0:
+                spectral_excess_rel = float(spectral_excess_abs / mp_bulk_max)
+
+            bulk_ipr_mean = bulk_stats.get("bulk_ipr_mean", np.nan)
+            ipr_lift = np.nan
+            ipr_lift_excess_pos = np.nan
+            if np.isfinite(bulk_ipr_mean) and bulk_ipr_mean != 0.0:
+                ipr_lift = float(trap_ipr / bulk_ipr_mean)
+                ipr_lift_excess_pos = float(max(ipr_lift - 1.0, 0.0))
+
+            bulk_top_5_mass_mean = bulk_stats.get("bulk_top_5_mass_mean", np.nan)
+            top_5_lift = np.nan
+            top_5_lift_excess_pos = np.nan
+            log1p_top_5_lift = np.nan
+            if np.isfinite(bulk_top_5_mass_mean) and bulk_top_5_mass_mean != 0.0:
+                top_5_lift = float(top_5_mass / bulk_top_5_mass_mean)
+                top_5_lift_excess_pos = float(max(top_5_lift - 1.0, 0.0))
+                log1p_top_5_lift = float(np.log1p(top_5_lift))
+
+            W_orig = original_basis_cache["W_true"]
+            X = W_orig.T @ W_orig
+            evals_x, evecs_x = np.linalg.eigh(X)
+            order = np.argsort(evals_x)[::-1]
+            lam = evals_x[order]
+            phi = evecs_x[:, order]
+            v_norm = np.linalg.norm(v_trap)
+            if v_norm > 0:
+                v_unit = v_trap / v_norm
+                p = np.abs(phi.T @ v_unit) ** 2
+                p_sum = float(np.sum(p))
+                if p_sum > 0:
+                    p = p / p_sum
+                ov_lam_weighted_mean = float(np.sum(p * lam))
+                ov_lam_weighted_var = float(np.sum(p * (lam - ov_lam_weighted_mean) ** 2))
+                ranks = np.arange(1, len(lam) + 1, dtype=float)
+                ov_rank_mean = float(np.sum(p * ranks))
+                ov_rank_std = float(np.sqrt(np.sum(p * (ranks - ov_rank_mean) ** 2)))
+                ov_hhi = float(np.sum(p ** 2))
+                ov_participation = float(1.0 / ov_hhi) if ov_hhi > 0 else np.nan
+                p_safe = p[p > 0]
+                ov_entropy = float(-np.sum(p_safe * np.log(p_safe))) if p_safe.size else np.nan
+                ov_max = float(np.max(p)) if p.size else np.nan
+            else:
+                ov_lam_weighted_mean = np.nan
+                ov_lam_weighted_var = np.nan
+                ov_rank_mean = np.nan
+                ov_rank_std = np.nan
+                ov_hhi = np.nan
+                ov_participation = np.nan
+                ov_entropy = np.nan
+                ov_max = np.nan
+
+            trap_variance_burden_ipr = float(spectral_excess_abs * ipr_lift_excess_pos * ov_lam_weighted_var) if np.all(
+                np.isfinite([spectral_excess_abs, ipr_lift_excess_pos, ov_lam_weighted_var])
+            ) else np.nan
+            trap_variance_burden_top5 = float(spectral_excess_abs * log1p_top_5_lift * ov_rank_mean) if np.all(
+                np.isfinite([spectral_excess_abs, log1p_top_5_lift, ov_rank_mean])
+            ) else np.nan
+            trap_variance_burden = trap_variance_burden_top5 if variant in {"top5", "both"} else trap_variance_burden_ipr
+
+            trap_result.update({
+                "spectral_excess_abs": spectral_excess_abs,
+                "spectral_excess_rel": spectral_excess_rel,
+                "trap_ipr": float(trap_ipr),
+                "ipr_lift": ipr_lift,
+                "ipr_lift_excess_pos": ipr_lift_excess_pos,
+                "top_5_lift": top_5_lift,
+                "top_5_lift_excess_pos": top_5_lift_excess_pos,
+                "log1p_top_5_lift": log1p_top_5_lift,
+                "ov_lam_weighted_mean": ov_lam_weighted_mean,
+                "ov_lam_weighted_var": ov_lam_weighted_var,
+                "ov_rank_mean": ov_rank_mean,
+                "ov_rank_std": ov_rank_std,
+                "ov_hhi": ov_hhi,
+                "ov_participation": ov_participation,
+                "ov_entropy": ov_entropy,
+                "ov_max": ov_max,
+                "trap_variance_burden_ipr": trap_variance_burden_ipr,
+                "trap_variance_burden_top5": trap_variance_burden_top5,
+                "trap_variance_burden": trap_variance_burden,
+            })
 
         for k, v in u_metrics.items():
             trap_result[f"u_{k}"] = v


### PR DESCRIPTION
### Motivation
- Provide optional trap "burden" metrics that quantify spectral excess, localization, and overlap-based variance for detected traps while preserving existing behavior and columns. 
- Only compute the extra, somewhat expensive metrics when explicitly requested via `trap_burden=True`, and allow selecting the public burden variant via `trap_burden_variant`.
- Keep prior top-mass and bulk-reference metrics from earlier PRs and avoid breaking existing APIs or remove_traps behavior.

### Description
- Added `trap_burden` (default False) and `trap_burden_variant` (default "top5") arguments to both the external `trap_analysis.analyze_traps` and the class method `WeightWatcher.analyze_traps`, and propagated these into `params` so defaults are unchanged unless enabled. 
- Extended `compute_bulk_trap_reference_metrics` to compute `bulk_ipr_mean` and `bulk_ipr_std` by unpermuting each bulk rank-1 mode and computing the IPR in the original basis. 
- Extended `analyze_single_trap` (now accepts `bulk_stats`) to compute gated burden metrics when `trap_burden=True`: `eval_perm`, `spectral_excess_abs`, `spectral_excess_rel`, `trap_ipr`, `ipr_lift`, `ipr_lift_excess_pos`, `top_5_lift`, `top_5_lift_excess_pos`, `log1p_top_5_lift`, overlap statistics on `X = W^T W` (`ov_lam_weighted_mean`, `ov_lam_weighted_var`, `ov_rank_mean`, `ov_rank_std`), optional diagnostics (`ov_hhi`, `ov_participation`, `ov_entropy`, `ov_max`), and burden outputs `trap_variance_burden_ipr`, `trap_variance_burden_top5`, and canonical `trap_variance_burden` (selected per `trap_burden_variant` with validation). 
- Appended all new columns to `_trap_result_columns` (no reordering or removal of any existing columns). 
- Added README documentation section "Trap variance burden" describing the two formulas and interpretive notes. 
- Added unit tests (no existing tests modified) to verify backward compatibility, presence of burden columns when enabled, finite-value checks, variant selection behavior, and invalid-variant handling. 

### Testing
- Ran the test subset: `pytest -q tests/test_analyze_traps.py tests/test_remove_traps.py`; result: `5 passed, 21 skipped` (torch-gated tests are skipped in this environment). 
- The new tests added for burden behavior were exercised as part of the test run and passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a0d8bf9083208e1aeab1037d12ea)