### PR TITLE
Restore PR359 trap burden metrics alongside current burden metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,12 +293,21 @@ For a complete walkthrough (including `remove_traps`), see: [Correlation Trap Wo
 
 #### Trap variance burden
 
-`analyze_traps` can optionally compute trap burden metrics with `trap_burden=True`.
+`analyze_traps` now exposes both the PR359 paper burden and the newer burden metrics.
 
-Two burden variants are available:
+PR359 paper burden:
+`trap_variance_burden_old = trap_delta^2 * trap_q * trap_top_sector_overlap^2`
 
-- IPR version: `trap_variance_burden_ipr = spectral_excess_abs * ipr_lift_excess_pos * ov_lam_weighted_var`
-- Top5 version: `trap_variance_burden_top5 = spectral_excess_abs * log1p_top_5_lift * ov_rank_mean`
+New IPR burden:
+`trap_variance_burden_ipr = spectral_excess_abs * ipr_lift_excess_pos * ov_lam_weighted_var`
+
+New Top5 burden:
+`trap_variance_burden_top5 = spectral_excess_abs * log1p_top_5_lift * ov_rank_mean`
+
+Canonical selected burden:
+`trap_variance_burden` is controlled by `trap_burden_variant`.
+
+`trap_variance_burden_old` is provided for PR359 compatibility and comparison against the newer burden formulations.
 
 Where:
 - `spectral_excess_abs` measures trap strength above the MP bulk edge.

--- a/tests/test_analyze_traps.py
+++ b/tests/test_analyze_traps.py
@@ -182,6 +182,51 @@ class TestAnalyzeTraps(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.watcher.analyze_traps(plot=False, savefig=False, trap_burden=True, trap_burden_variant="bad")
 
+    def test_pr359_old_metrics_exist(self):
+        df = self.watcher.analyze_traps(plot=False, savefig=False, rng=1337)
+        required = {
+            "trap_delta", "trap_ipr", "trap_q", "trap_diffuseness",
+            "trap_q_uniform", "trap_diffuseness_uniform", "trap_top_sector_overlap",
+            "trap_variance_burden_old", "layer_trap_variance_burden",
+            "top_sector_l", "top_sector_l_effective",
+        }
+        self.assertTrue(required.issubset(set(df.columns)))
+
+    def test_pr359_old_formula_rowwise_and_layer_aggregate(self):
+        df = self.watcher.analyze_traps(plot=False, savefig=False, rng=1337)
+        if len(df) == 0:
+            self.skipTest("No traps detected in this environment")
+        mask = np.isfinite(df["trap_delta"]) & np.isfinite(df["trap_q"]) & np.isfinite(df["trap_top_sector_overlap"]) & np.isfinite(df["trap_variance_burden_old"])
+        if mask.any():
+            expected = (df.loc[mask, "trap_delta"] ** 2) * df.loc[mask, "trap_q"] * (df.loc[mask, "trap_top_sector_overlap"] ** 2)
+            self.assertTrue(np.allclose(df.loc[mask, "trap_variance_burden_old"], expected))
+        for _, g in df.groupby("layer_id"):
+            layer_val = g["layer_trap_variance_burden"].iloc[0]
+            expected_layer = np.nansum(g["trap_variance_burden_old"].to_numpy())
+            self.assertTrue(np.isclose(layer_val, expected_layer, equal_nan=True))
+
+    def test_top_sector_l_argument(self):
+        df1 = self.watcher.analyze_traps(plot=False, savefig=False, rng=1337, top_sector_l=1)
+        df2 = self.watcher.analyze_traps(plot=False, savefig=False, rng=1337, top_sector_l=2)
+        if len(df1) > 0:
+            self.assertTrue((df1["top_sector_l"] == 1).all())
+            self.assertTrue(((df1["top_sector_l_effective"] >= 1) & (df1["top_sector_l_effective"] <= 1)).all())
+        if len(df2) > 0:
+            self.assertTrue((df2["top_sector_l"] == 2).all())
+            self.assertTrue(((df2["top_sector_l_effective"] >= 1) & (df2["top_sector_l_effective"] <= 2)).all())
+
+    def test_old_and_new_burdens_coexist(self):
+        df = self.watcher.analyze_traps(plot=False, savefig=False, trap_burden=True, trap_burden_variant="top5")
+        for col in ["trap_variance_burden_old", "trap_variance_burden_ipr", "trap_variance_burden_top5", "trap_variance_burden"]:
+            self.assertIn(col, df.columns)
+
+    def test_no_trap_fft_api_or_columns(self):
+        with self.assertRaises(TypeError):
+            self.watcher.analyze_traps(plot=False, savefig=False, trap_fft=True)
+        df = self.watcher.analyze_traps(plot=False, savefig=False)
+        self.assertFalse(any(c.startswith("trap_fft") for c in df.columns))
+        self.assertFalse(any(c.startswith("trap_variance_burden__") for c in df.columns))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_remove_traps.py
+++ b/tests/test_remove_traps.py
@@ -226,7 +226,13 @@ def test_remove_traps_accepts_traps_dataframe_and_returns_verify_df(monkeypatch)
         lambda model=None, layers=None, params=None, base_model=None: [ww_layer],
     )
 
-    trap_df = pd.DataFrame([{"layer_id": 0, "trap_index": 1}])
+    trap_df = pd.DataFrame([{
+        "layer_id": 0, "trap_index": 1,
+        "trap_variance_burden_old": 0.1,
+        "trap_variance_burden_ipr": 0.2,
+        "trap_variance_burden_top5": 0.3,
+        "trap_variance_burden": 0.4,
+    }])
     out_model, verify_df = watcher.remove_traps(
         model={"dummy_weight": np.array([1.0])},
         layers=[],

--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -31,6 +31,7 @@ def analyze_traps(
     rng=None,
     trap_burden=False,
     trap_burden_variant="top5",
+    top_sector_l=1,
 ):
     """Externalized implementation for WeightWatcher.analyze_traps()."""
     if layers is None:
@@ -77,6 +78,7 @@ def analyze_traps(
     params["rng"] = remove_traps_ops._normalize_trap_rng(rng=rng)
     params["trap_burden"] = bool(trap_burden)
     params["trap_burden_variant"] = trap_burden_variant
+    params["top_sector_l"] = int(top_sector_l)
 
     wwcore.logger.debug("params {}".format(params))
     if not watcher.valid_params(params):

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3708,7 +3708,8 @@ class WeightWatcher:
                 peft=DEFAULT_PEFT,
                 rng=None,
                 trap_burden=False,
-                trap_burden_variant="top5"):
+                trap_burden_variant="top5",
+                top_sector_l=1):
         """Analyze randomized correlation traps and return one row per trap.
 
         This method follows the randomized/permuted trap workflow:
@@ -3755,6 +3756,7 @@ class WeightWatcher:
             rng=rng,
             trap_burden=trap_burden,
             trap_burden_variant=trap_burden_variant,
+            top_sector_l=top_sector_l,
         )
 
     def _trap_result_columns(self):
@@ -3786,6 +3788,11 @@ class WeightWatcher:
             "ov_rank_mean", "ov_rank_std",
             "ov_hhi", "ov_participation", "ov_entropy", "ov_max",
             "trap_variance_burden_ipr", "trap_variance_burden_top5", "trap_variance_burden",
+            "top_sector_l", "top_sector_l_effective",
+            "trap_delta", "trap_q", "trap_diffuseness",
+            "trap_q_uniform", "trap_diffuseness_uniform",
+            "trap_top_sector_overlap", "trap_variance_burden_old",
+            "layer_trap_variance_burden",
             "permute_fingerprint",
         ]
 
@@ -3818,9 +3825,70 @@ class WeightWatcher:
             )
             trap_row.update(bulk_stats)
             trap_rows.append(trap_row)
+        if trap_rows:
+            layer_trap_variance_burden = float(np.nansum([row.get("trap_variance_burden_old", np.nan) for row in trap_rows]))
+            for row in trap_rows:
+                row["layer_trap_variance_burden"] = layer_trap_variance_burden
 
         self.apply_unpermute_W(ww_layer, params)
         return trap_rows
+
+    def compute_trap_delta(self, eval_perm, mp_bulk_max):
+        if not (np.isfinite(eval_perm) and np.isfinite(mp_bulk_max)) or mp_bulk_max <= 0:
+            return np.nan
+        return float(max(eval_perm - mp_bulk_max, 0.0) / mp_bulk_max)
+
+    def compute_trap_ipr_q(self, v):
+        try:
+            v = np.asarray(v, dtype=float).ravel()
+            m = len(v)
+            if m == 0:
+                return np.nan, np.nan
+            norm = float(np.linalg.norm(v))
+            if not np.isfinite(norm) or norm <= 0:
+                return np.nan, np.nan
+            vu = v / norm
+            trap_ipr = float(np.sum(vu ** 4))
+            ipr_pt = 3.0 / (m + 2.0)
+            trap_q = (trap_ipr - ipr_pt) / (1.0 - ipr_pt)
+            trap_q = float(np.clip(max(trap_q, 0.0), 0.0, 1.0))
+            return trap_ipr, trap_q
+        except Exception:
+            return np.nan, np.nan
+
+    def compute_trap_ipr_q_uniform(self, v):
+        try:
+            v = np.asarray(v, dtype=float).ravel()
+            m = len(v)
+            if m == 0:
+                return np.nan, np.nan
+            norm = float(np.linalg.norm(v))
+            if not np.isfinite(norm) or norm <= 0:
+                return np.nan, np.nan
+            vu = v / norm
+            trap_ipr = float(np.sum(vu ** 4))
+            ipr_uniform = 1.0 / m
+            trap_q = (trap_ipr - ipr_uniform) / (1.0 - ipr_uniform)
+            trap_q = float(np.clip(max(trap_q, 0.0), 0.0, 1.0))
+            return trap_ipr, trap_q
+        except Exception:
+            return np.nan, np.nan
+
+    def compute_top_sector_overlap(self, overlaps, top_sector_l):
+        ov = np.asarray(overlaps, dtype=float).ravel()
+        if ov.size == 0:
+            return np.nan, 0
+        s = float(np.sum(ov))
+        if s > 0 and np.isfinite(s):
+            ov = ov / s
+        top_sector_l_effective = int(min(max(int(top_sector_l), 1), len(ov)))
+        return float(np.sum(ov[:top_sector_l_effective])), top_sector_l_effective
+
+    def compute_trap_variance_burden(self, trap_delta, trap_q, trap_top_sector_overlap):
+        vals = [trap_delta, trap_q, trap_top_sector_overlap]
+        if not np.all(np.isfinite(vals)):
+            return np.nan
+        return float((trap_delta ** 2) * trap_q * (trap_top_sector_overlap ** 2))
 
 
     def apply_trap_mp_fit(self, ww_layer, params=None):
@@ -3989,7 +4057,27 @@ class WeightWatcher:
         v_oi = self._trap_vector_order_invariant_stats(v_trap)
 
         eval_perm = sigma_perm ** 2
-        trap_ipr = 0.5 * (float(np.sum(u_trap ** 4)) + float(np.sum(v_trap ** 4)))
+        left_ipr, left_q = self.compute_trap_ipr_q(u_trap)
+        right_ipr, right_q = self.compute_trap_ipr_q(v_trap)
+        _, left_q_uniform = self.compute_trap_ipr_q_uniform(u_trap)
+        _, right_q_uniform = self.compute_trap_ipr_q_uniform(v_trap)
+        trap_ipr = float(np.nanmean([left_ipr, right_ipr])) if np.any(np.isfinite([left_ipr, right_ipr])) else np.nan
+        finite_q = [q for q in [left_q, right_q] if np.isfinite(q)]
+        if len(finite_q) == 2:
+            trap_q = float(np.sqrt(finite_q[0] * finite_q[1]))
+        else:
+            trap_q = finite_q[0] if finite_q else np.nan
+        finite_qu = [q for q in [left_q_uniform, right_q_uniform] if np.isfinite(q)]
+        if len(finite_qu) == 2:
+            trap_q_uniform = float(np.sqrt(finite_qu[0] * finite_qu[1]))
+        else:
+            trap_q_uniform = finite_qu[0] if finite_qu else np.nan
+        trap_diffuseness = float(1.0 - trap_q) if np.isfinite(trap_q) else np.nan
+        trap_diffuseness_uniform = float(1.0 - trap_q_uniform) if np.isfinite(trap_q_uniform) else np.nan
+        top_sector_l = int(params.get("top_sector_l", 1))
+        trap_top_sector_overlap, top_sector_l_effective = self.compute_top_sector_overlap(right_overlaps, top_sector_l)
+        trap_delta = self.compute_trap_delta(eval_perm, float(ww_layer.bulk_max))
+        trap_variance_burden_old = self.compute_trap_variance_burden(trap_delta, trap_q, trap_top_sector_overlap)
         trap_result = {
             "layer_id": ww_layer.layer_id,
             "name": ww_layer.name,
@@ -4020,6 +4108,16 @@ class WeightWatcher:
             "right_overlap_ipr": right_overlap_ipr,
             "top_5_mass": float(top_5_mass),
             "top_10_mass": float(top_10_mass),
+            "top_sector_l": top_sector_l,
+            "top_sector_l_effective": int(top_sector_l_effective),
+            "trap_delta": trap_delta,
+            "trap_ipr": trap_ipr,
+            "trap_q": trap_q,
+            "trap_diffuseness": trap_diffuseness,
+            "trap_q_uniform": trap_q_uniform,
+            "trap_diffuseness_uniform": trap_diffuseness_uniform,
+            "trap_top_sector_overlap": trap_top_sector_overlap,
+            "trap_variance_burden_old": trap_variance_burden_old,
             "trap_detected": True,
             "trap_eval_minus_bulk": float(eval_perm - ww_layer.bulk_max),
         }


### PR DESCRIPTION
### Motivation
- Restore the PR359 paper-facing trap-burden metrics alongside the newer burden metrics so `analyze_traps` can produce both sets for compatibility and comparison.
- Provide API support for the PR359 top-sector parameter and helper functions to compute the PR359 formulas without changing existing burden logic or FFT behavior.

### Description
- Added `top_sector_l=1` public API to `WeightWatcher.analyze_traps` and passed it into `trap_analysis.analyze_traps` via `params` to preserve backward compatibility (default 1).
- Restored/implemented PR359 helper methods on `WeightWatcher`: `compute_trap_delta`, `compute_trap_ipr_q`, `compute_trap_ipr_q_uniform`, `compute_top_sector_overlap`, and `compute_trap_variance_burden` and used them when analyzing traps.
- Extended trap output schema (`_trap_result_columns`) and per-trap rows to include PR359 fields: `top_sector_l`, `top_sector_l_effective`, `trap_delta`, `trap_ipr`, `trap_q`, `trap_diffuseness`, `trap_q_uniform`, `trap_diffuseness_uniform`, `trap_top_sector_overlap`, and `trap_variance_burden_old` while keeping existing new-burden fields intact.
- Computed PR359 per-trap metrics inside `analyze_single_trap` (with left/right aggregation as requested) and computed a layer-level aggregate `layer_trap_variance_burden` in `apply_analyze_traps` (NaN-ignoring sum written to each trap row for the layer).
- Preserved all existing new burden computations and `trap_burden_variant` selection logic and avoided reintroducing any FFT/trap-FFT/burden-sweep features; updated `trap_analysis.py`, `weightwatcher.py`, `tests/*` and `README.md` accordingly.

### Testing
- Added tests in `tests/test_analyze_traps.py` to assert presence of PR359 columns, row-wise PR359 formula equality, per-layer aggregate equality, `top_sector_l` behavior, coexistence of old/new burdens, and absence of `trap_fft`/sweep columns, and updated `tests/test_remove_traps.py` to ensure `remove_traps` accepts a traps DataFrame that contains burden columns.
- Ran: `pytest -q tests/test_analyze_traps.py tests/test_remove_traps.py`, resulting in `6 passed, 26 skipped` (all new/updated tests executed where applicable).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f21f1cecd88320b905b00d4022be07)