### PR TITLE
Bump WeightWatcher version to 0.8.3

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3]
+Version bump to 0.8.3
+
 ## [0.8.1]
 Enabled trap histogram plots by default in `analyze_traps(...)` and `remove_traps(...)`
 Added shared trap histogram overlays with dashed per-trap vertical lines and consistent severity-aware color mapping

--- a/weightwatcher/__init__.py
+++ b/weightwatcher/__init__.py
@@ -19,7 +19,7 @@ from .weightwatcher import WeightWatcher
 
 __name__ = "weightwatcher"
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 __license__ = "Apache License, Version 2.0"
 __description__ = "Diagnostic Tool for Deep Neural Networks"


### PR DESCRIPTION
### Motivation
- Release a patch version by updating the package version to `0.8.3` and record the change in the project changelog.

### Description
- Updated `__version__` in `weightwatcher/__init__.py` from `0.8.2` to `0.8.3` and added a `## [0.8.3]` entry to `Changelog.txt` noting the version bump.

### Testing
- No automated tests were run for this change (version/changelog update only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f250ecfd60832095358f85f1619a05)