### PR TITLE
Bump version to 0.8.5 for PR368

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.5]
+Version bump to 0.8.5 (PR368)
+
 ## [0.8.3]
 Version bump to 0.8.3
 

--- a/weightwatcher/__init__.py
+++ b/weightwatcher/__init__.py
@@ -19,7 +19,7 @@ from .weightwatcher import WeightWatcher
 
 __name__ = "weightwatcher"
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 __license__ = "Apache License, Version 2.0"
 __description__ = "Diagnostic Tool for Deep Neural Networks"


### PR DESCRIPTION
### Motivation
- Bump package version to `0.8.5` to mark the PR368 release and update project metadata.

### Description
- Updated `__version__` in `weightwatcher/__init__.py` from `0.8.4` to `0.8.5` and added a `0.8.5` entry to `Changelog.txt` noting the PR368 version bump.

### Testing
- No automated tests were run because this is a version/changelog-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3a23616bc83208415a9e5fc523306)