### PR TITLE
Expose WeightWatcher in package API and document cached trap ablation workflow

### DIFF
--- a/docs_trap_features.md
+++ b/docs_trap_features.md
@@ -8,6 +8,9 @@ This guide explains how to use the new correlation-trap workflow that was recent
 
 - `analyze_traps(...)` inspects selected layers and reports candidate correlation-trap modes.
 - `remove_traps(...)` removes selected trap modes from those layers and returns an updated model.
+- `randomize_model(...)` randomizes once and returns reusable state for faster ablation loops.
+
+These are intended as **public WeightWatcher APIs** on `ww.WeightWatcher`.
 
 Use this flow when you suspect a layer looks random except for isolated spikes (classic trap signature).
 
@@ -119,3 +122,10 @@ ablated_model = watcher.remove_traps(randomized_model=randomized_model, traps=tr
 ```
 
 Warning: `trap_burden_mode="fast"` uses approximate overlap and bulk-reference metrics for speed. Use `trap_burden_mode="full"` for expensive original-basis diagnostics.
+
+### Why this is faster (and how to avoid long runs)
+
+- Reuse `randomized_model` + `trap_state` across iterative removals instead of re-running full randomization.
+- Set `return_artifacts=True` in `analyze_traps(...)` and pass that same `trap_state` into `remove_traps(...)` so trap artifacts are cached and reused.
+- Use `trap_burden_mode="fast"` and a small `bulk_mode_sample` during exploration; switch to `"full"` only for final verification.
+- Restrict analysis to a small `layers=[...]` subset first, then expand after confirming expected behavior.

--- a/weightwatcher/__init__.py
+++ b/weightwatcher/__init__.py
@@ -28,5 +28,8 @@ __author__ = "Calculation Consulting"
 __email__ = "info@calculationconsulting.com"
 __copyright__ = "Calculation Consulting"
 
-__all__ = ["__name__", "__version__", "__license__", "__description__",
-          "__url__", "__author__", "__email__", "__copyright__"]
+__all__ = [
+    "__name__", "__version__", "__license__", "__description__",
+    "__url__", "__author__", "__email__", "__copyright__",
+    "WeightWatcher",
+]


### PR DESCRIPTION
### Motivation
- Make the correlation-trap workflow clear and discoverable as public APIs and provide practical guidance to avoid extremely long randomized ablation runs. 
- Help users speed up iterative ablation by documenting reuse/caching patterns (randomized state, artifacts, and fast burden mode) without changing algorithmic behavior.

### Description
- Export `WeightWatcher` from the package by adding it to `__all__` in `weightwatcher/__init__.py` so the primary class is part of the public API surface. 
- Update `docs_trap_features.md` to declare `randomize_model(...)`, `analyze_traps(...)`, and `remove_traps(...)` as public `ww.WeightWatcher` APIs and add a short section explaining cached ablation: reuse `randomized_model` + `trap_state`, set `return_artifacts=True`, use `trap_burden_mode="fast"` and `bulk_mode_sample` for exploration, and restrict `layers=[...]` during initial runs. 
- No trap algorithm or runtime logic was modified; this is an API-surface and documentation-only change.

### Testing
- Ran `pytest -q tests/test_trap_ablation_workflow.py` in this environment which reported `1 skipped` and no failing assertions. 
- No additional automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44b21dc0c83209eda268cffa8fdf1)