### PR TITLE
Add basic notebook for evolution-travel trap workflow

### DIFF
--- a/notebooks/basic_evolution_travel_workflow.ipynb
+++ b/notebooks/basic_evolution_travel_workflow.ipynb
@@ -1,0 +1,223 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic Evolution-Travel Trap Workflow (Single-Layer Demo)\n",
+    "\n",
+    "This notebook demonstrates a **minimal, fully public-API** workflow:\n",
+    "1. Build a tiny one-layer model with a deliberately localized trap.\n",
+    "2. Randomize the model with `randomize_model(...)`.\n",
+    "3. Run `analyze_traps(...)` to detect a trap and inspect localization metrics.\n",
+    "4. Remove that trap with `remove_traps(...)`.\n",
+    "\n",
+    "Each step includes timing with `time.perf_counter()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import weightwatcher as ww\n",
+    "\n",
+    "pd.set_option(\"display.max_columns\", None)\n",
+    "pd.set_option(\"display.width\", 200)\n",
+    "\n",
+    "print(\"weightwatcher version:\", ww.__version__)\n",
+    "print(\"torch version:\", torch.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1) Create a tiny single-layer model with a highly localized trap\n",
+    "\n",
+    "We start from random Gaussian weights, then inject one large entry (`trap_strength`) at a single coordinate.\n",
+    "That creates a strongly localized outlier direction by construction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "class SingleLayerTrapNet(nn.Module):\n",
+    "    def __init__(self, in_dim=64, out_dim=64):\n",
+    "        super().__init__()\n",
+    "        self.fc = nn.Linear(in_dim, out_dim, bias=False)\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.fc(x)\n",
+    "\n",
+    "seed = 123\n",
+    "torch.manual_seed(seed)\n",
+    "np.random.seed(seed)\n",
+    "\n",
+    "model = SingleLayerTrapNet(64, 64)\n",
+    "with torch.no_grad():\n",
+    "    model.fc.weight.normal_(mean=0.0, std=0.02)\n",
+    "    trap_row, trap_col = 7, 11\n",
+    "    trap_strength = 5.0\n",
+    "    model.fc.weight[trap_row, trap_col] = trap_strength\n",
+    "\n",
+    "original_weight = model.fc.weight.detach().cpu().clone()\n",
+    "print(\"Weight shape:\", tuple(original_weight.shape))\n",
+    "print(\"Injected trap location/value:\", (trap_row, trap_col), float(original_weight[trap_row, trap_col]))\n",
+    "print(\"Global max |W|:\", float(original_weight.abs().max()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2) Randomize once with the evolution-travel workflow entry point"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "watcher = ww.WeightWatcher(model=model)\n",
+    "\n",
+    "t0 = time.perf_counter()\n",
+    "randomized_model, trap_state = watcher.randomize_model(model=model, layers=[], rng=123, return_state=True, pool=False)\n",
+    "t_randomize = time.perf_counter() - t0\n",
+    "\n",
+    "rand_weight = randomized_model.fc.weight.detach().cpu().clone()\n",
+    "print(f\"randomize_model runtime: {t_randomize:.4f} seconds\")\n",
+    "print(\"Same matrix as original?\", torch.allclose(original_weight, rand_weight))\n",
+    "print(\"Frobenius norm(original-randomized):\", float(torch.linalg.norm(original_weight - rand_weight)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3) Re-run randomization to confirm weight matrix changes again"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "t0 = time.perf_counter()\n",
+    "randomized_model_2, trap_state_2 = watcher.randomize_model(model=model, layers=[], rng=456, return_state=True, pool=False)\n",
+    "t_randomize2 = time.perf_counter() - t0\n",
+    "\n",
+    "rand_weight_2 = randomized_model_2.fc.weight.detach().cpu().clone()\n",
+    "print(f\"Second randomize_model runtime: {t_randomize2:.4f} seconds\")\n",
+    "print(\"First randomized == second randomized?\", torch.allclose(rand_weight, rand_weight_2))\n",
+    "print(\"Frobenius norm(rand1-rand2):\", float(torch.linalg.norm(rand_weight - rand_weight_2)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4) Detect traps with `analyze_traps(...)` and inspect localization / burden"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "t0 = time.perf_counter()\n",
+    "trap_df, trap_state = watcher.analyze_traps(\n",
+    "    randomized_model=randomized_model,\n",
+    "    trap_state=trap_state,\n",
+    "    return_artifacts=True,\n",
+    "    trap_burden=True,\n",
+    "    trap_burden_variant=\"top5\",\n",
+    "    plot=False,\n",
+    "    savefig=False,\n",
+    "    pool=False,\n",
+    ")\n",
+    "t_analyze = time.perf_counter() - t0\n",
+    "\n",
+    "print(f\"analyze_traps runtime: {t_analyze:.4f} seconds\")\n",
+    "print(\"Number of detected traps:\", len(trap_df))\n",
+    "\n",
+    "cols_to_show = [\n",
+    "    c for c in [\n",
+    "        \"layer_id\", \"name\", \"trap_index\", \"trap_mode_index\",\n",
+    "        \"matrix_entropy\", \"vector_entropy\", \"participation_ratio\", \"localization_ratio\",\n",
+    "        \"trap_burden\", \"trap_burden_top5\"\n",
+    "    ] if c in trap_df.columns\n",
+    "]\n",
+    "\n",
+    "if len(trap_df) > 0:\n",
+    "    display(trap_df[cols_to_show].head(10))\n",
+    "    top_trap = trap_df.iloc[[0]]\n",
+    "else:\n",
+    "    top_trap = None\n",
+    "    print(\"No trap rows found. Try increasing matrix size or trap_strength.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5) Remove a detected trap with `remove_traps(...)`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "if top_trap is None:\n",
+    "    print(\"Skipping remove_traps because no trap was detected.\")\n",
+    "else:\n",
+    "    t0 = time.perf_counter()\n",
+    "    ablated_model, verify_df = watcher.remove_traps(\n",
+    "        randomized_model=randomized_model,\n",
+    "        traps=top_trap,\n",
+    "        trap_state=trap_state,\n",
+    "        plot=False,\n",
+    "        verify=True,\n",
+    "        return_verify_df=True,\n",
+    "        pool=False,\n",
+    "    )\n",
+    "    t_remove = time.perf_counter() - t0\n",
+    "\n",
+    "    before = randomized_model.fc.weight.detach().cpu()\n",
+    "    after = ablated_model.fc.weight.detach().cpu()\n",
+    "\n",
+    "    print(f\"remove_traps runtime: {t_remove:.4f} seconds\")\n",
+    "    print(\"Weights changed after trap removal?\", not torch.allclose(before, after))\n",
+    "    print(\"Frobenius norm(before-after):\", float(torch.linalg.norm(before - after)))\n",
+    "    display(verify_df.head(10))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, self-contained notebook example that demonstrates the randomized trap analysis and ablation workflow for users learning the evolution-travel APIs.
- Make it easy to reproduce a localized correlation-trap case and exercise the public APIs end-to-end with simple, well-documented cells.

### Description
- Add `notebooks/basic_evolution_travel_workflow.ipynb` which builds a tiny single-layer `nn.Linear` model, injects a highly localized trap, and captures the original weights.
- Demonstrate the full public workflow using `WeightWatcher.randomize_model(...)`, `WeightWatcher.analyze_traps(...)`, and `WeightWatcher.remove_traps(...)`, including a second `randomize_model` call to show the randomized matrix changes.
- Include simple timing instrumentation using `time.perf_counter()` around `randomize_model`, `analyze_traps`, and `remove_traps`, and select deterministic local execution via `pool=False` for notebook clarity.
- Surface localization and trap burden metrics in the `analyze_traps` output and verify weight changes after applying `remove_traps`.

### Testing
- Parsed the written notebook JSON and validated the notebook `nbformat` and cell count with `python -c` JSON check, which succeeded and reported `nbformat` 4 and 12 cells.
- Verified the notebook file was created at `notebooks/basic_evolution_travel_workflow.ipynb` and is present in the repository tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f44d389a1c83208fec3b8f9a2ac5dd)