### PR TITLE
Make analyze_traps return_artifacts default to True

### DIFF
--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -59,7 +59,7 @@ def analyze_traps(
     bulk_mode_sample=10,
     compute_original_trap_svd=None,
     trap_state=None,
-    return_artifacts=False,
+    return_artifacts=True,
     permuted_ids=None,
     already_randomized=False,
 ):

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3758,7 +3758,7 @@ class WeightWatcher:
                 top_sector_l=1,
                 randomized_model=None,
                 trap_state=None,
-                return_artifacts=False,
+                return_artifacts=True,
                 permuted_ids=None,
                 trap_burden_mode="fast",
                 compute_original_basis=None,


### PR DESCRIPTION
### Motivation
- Ensure trap analysis routines return diagnostic artifacts by default so callers receive full trap data without needing to set `return_artifacts` explicitly.

### Description
- Changed the default value of the `return_artifacts` parameter from `False` to `True` in `analyze_traps` implementations in `weightwatcher/weightwatcher.py` and `weightwatcher/trap_analysis.py`.

### Testing
- Ran the test suite with `pytest -q` and existing tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50043f85483209c264d85ca847b0e)