### PR TITLE
Make analyze_traps default to plot=False

### DIFF
--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -37,7 +37,7 @@ def analyze_traps(
     max_size=None,
     max_N=wwcore.DEFAULT_MAX_N,
     glorot_fix=False,
-    plot=True,
+    plot=False,
     savefig=wwcore.DEF_SAVE_DIR,
     conv2d_norm=True,
     ww2x=wwcore.DEFAULT_WW2X,

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3744,7 +3744,7 @@ class WeightWatcher:
                 min_evals=DEFAULT_MIN_EVALS, max_evals=DEFAULT_MAX_EVALS,
                 min_size=None, max_size=None, max_N=DEFAULT_MAX_N,
                 glorot_fix=False,
-                plot=True, savefig=DEF_SAVE_DIR,
+                plot=False, savefig=DEF_SAVE_DIR,
                 conv2d_norm=True,
                 ww2x=DEFAULT_WW2X, pool=DEFAULT_POOL,
                 conv2d_fft=False, fft=False, channels=None,


### PR DESCRIPTION
### Motivation
- Make `plot` opt-out by default for trap analysis to avoid unexpected plotting and ensure the public API and internal implementation behave consistently.

### Description
- Changed the `plot` default from `True` to `False` in `analyze_traps` signatures in `weightwatcher/weightwatcher.py` and `weightwatcher/trap_analysis.py` so callers inherit `plot=False` unless overridden.

### Testing
- Ran `python -m pytest -q tests/test_analyze_traps.py -k "not slow"`, which completed and reported the selected tests were skipped (24 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f50319defc8320af7afc5cad93593c)