### PR TITLE
Make `trap_index` one-based across trap analysis/removal, add validation for cached artifacts

### DIFF
--- a/tests/test_trap_component_summary.py
+++ b/tests/test_trap_component_summary.py
@@ -19,7 +19,7 @@ def test_top_trap_component_row_extracts_top_10_weight_and_coeff_pairs():
     row = {
         "layer_id": 7,
         "name": "dense",
-        "trap_index": 0,
+        "trap_index": 1,
         "trap_assessment": "mixed",
         "trap_risk_score": 0.4,
         "T_orig": trap,

--- a/tests/test_trap_compute_efficiency.py
+++ b/tests/test_trap_compute_efficiency.py
@@ -45,10 +45,7 @@ class SVDCallCounter:
 
 
 def _normalize_selected(df):
-    selected = df.copy()
-    if "trap_index" in selected.columns and selected["trap_index"].min() == 0:
-        selected["trap_index"] = selected["trap_index"].astype(int) + 1
-    return selected
+    return df.copy()
 
 
 def _workflow(monkeypatch):

--- a/weightwatcher/remove_traps.py
+++ b/weightwatcher/remove_traps.py
@@ -307,7 +307,11 @@ def remove_traps(ww, randomized_model=None, layers=[], trap_indices=None, traps=
                 cached_artifacts = trap_artifacts if trap_artifacts is not None else layer_state.get("artifacts", [])
                 selected_trap_indices = layer_selected_trap_indices
                 if selected_trap_indices is None:
-                    selected_trap_indices = [int(a.get("trap_index", i + 1)) for i, a in enumerate(cached_artifacts)]
+                    if any("trap_index" not in a for a in cached_artifacts):
+                        raise ValueError(
+                            f"cached trap artifacts for layer {ww_layer.layer_id} are missing required one-based trap_index values"
+                        )
+                    selected_trap_indices = [int(a["trap_index"]) for a in cached_artifacts]
                 trace_event("remove_traps_cached_start", phase="remove_traps", layer_id=int(ww_layer.layer_id), selected_trap_indices=list(selected_trap_indices), cached=True)
                 old_W = ww_layer.Wmats[0]; new_W = old_W.copy()
                 selected_rows = layer_traps if layer_traps is not None and len(layer_traps) > 0 else None

--- a/weightwatcher/trap_analysis.py
+++ b/weightwatcher/trap_analysis.py
@@ -171,14 +171,14 @@ def analyze_traps(
                 if params.get(wwcore.PLOT, False):
                     trap_infos = []
                     for row in layer_rows:
-                        trap_idx_zero_based = int(row.get("trap_index", -1))
+                        trap_idx_one_based = int(row.get("trap_index", -1))
                         trap_matrix = row.get("T_orig", None)
-                        if trap_idx_zero_based < 0 or trap_matrix is None:
+                        if trap_idx_one_based < 1 or trap_matrix is None:
                             continue
 
                         trap_infos.append(
                             {
-                                "trap_index": trap_idx_zero_based + 1,
+                                "trap_index": trap_idx_one_based,
                                 "trap_matrix": trap_matrix,
                                 "trap_assessment": row.get("trap_assessment", "mixed"),
                                 "trap_risk_score": row.get("trap_risk_score", 0.0),
@@ -238,7 +238,7 @@ def _top_trap_component_row(row, weight_matrix, top_k=10):
     out = {
         "layer_id": row.get("layer_id"),
         "name": row.get("name"),
-        "trap_index": int(row.get("trap_index", -1)) + 1,
+        "trap_index": int(row.get("trap_index", -1)),
         "trap_assessment": row.get("trap_assessment", "mixed"),
         "trap_risk_score": float(row.get("trap_risk_score", 0.0)),
     }

--- a/weightwatcher/weightwatcher.py
+++ b/weightwatcher/weightwatcher.py
@@ -3904,11 +3904,11 @@ class WeightWatcher:
         trap_rows=[]; artifacts=[]
         pids = np.asarray(ww_layer.permute_ids[0]) if len(getattr(ww_layer,'permute_ids',[]))>0 else None
         fp = hashlib.sha1(pids.tobytes()).hexdigest() if pids is not None else None
-        for trap_index, mode_index in enumerate(trap_mode_indices):
+        for trap_index, mode_index in enumerate(trap_mode_indices, start=1):
             trap_row = self.analyze_single_trap(ww_layer, trap_mode_index=mode_index, original_basis_cache=original_basis_cache, params=params, trap_index=trap_index, bulk_stats=bulk_stats, precomputed_svd=(U_perm,S_perm,Vh_perm))
             trap_row.update(bulk_stats); trap_row['permute_fingerprint']=fp
             trap_rows.append(trap_row)
-            artifacts.append({"layer_id": int(ww_layer.layer_id), "trap_index": int(trap_index+1), "trap_mode_index": int(mode_index), "sigma_perm": float(S_perm[mode_index]), "permute_fingerprint": fp, "T_perm": trap_row.get("T_perm"), "T_orig_raw": trap_row.get("T_orig"), "u_trap_perm": U_perm[:, mode_index], "v_trap_perm": Vh_perm[mode_index, :]})
+            artifacts.append({"layer_id": int(ww_layer.layer_id), "trap_index": int(trap_index), "trap_mode_index": int(mode_index), "sigma_perm": float(S_perm[mode_index]), "permute_fingerprint": fp, "T_perm": trap_row.get("T_perm"), "T_orig_raw": trap_row.get("T_orig"), "u_trap_perm": U_perm[:, mode_index], "v_trap_perm": Vh_perm[mode_index, :]})
         if trap_rows:
             layer_trap_variance_burden = float(np.nansum([row.get("trap_variance_burden_old", np.nan) for row in trap_rows]))
             for row in trap_rows: row["layer_trap_variance_burden"] = layer_trap_variance_burden
@@ -4121,7 +4121,7 @@ class WeightWatcher:
         }
 
 
-    def analyze_single_trap(self, ww_layer, trap_mode_index, original_basis_cache=None, params=None, trap_index=0, bulk_stats=None, precomputed_svd=None):
+    def analyze_single_trap(self, ww_layer, trap_mode_index, original_basis_cache=None, params=None, trap_index=1, bulk_stats=None, precomputed_svd=None):
         if params is None: params = DEFAULT_PARAMS.copy()
         if original_basis_cache is None:
             original_basis_cache = self.compute_original_basis_for_traps(ww_layer, params=params)


### PR DESCRIPTION
### Motivation

- Remove inconsistent zero-vs-one-based indexing for `trap_index` across trap analysis, artifact caching, plotting and removal logic to prevent off-by-one errors.
- Make cached artifacts' `trap_index` explicit and validated so `remove_traps` can reliably select artifacts without guessing indices.

### Description

- Update trap analysis to treat `trap_index` as one-based: remove the previous `+1` adjustment in `_top_trap_component_row`, require `trap_index >= 1` when plotting, and set `enumerate(trap_mode_indices, start=1)` so produced artifacts carry one-based `trap_index` values.
- Change `analyze_single_trap` default `trap_index` parameter to `1` to match the one-based convention.
- Tighten `remove_traps` behavior to raise a `ValueError` if cached artifacts are missing required one-based `trap_index` values and to use the artifact's `trap_index` directly when selecting indices.
- Update tests and helper functions to reflect the new one-based indexing by adjusting expected values in `tests/test_trap_component_summary.py` and by removing the prior normalization in `tests/test_trap_compute_efficiency.py`.

### Testing

- Ran the updated unit tests `tests/test_trap_component_summary.py` and `tests/test_trap_compute_efficiency.py`, and they passed.
- Executed the trap-analysis related unit tests exercising `analyze_traps` and `remove_traps` code paths, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52047c1d88320b1cefe7f1315f522)