### PR TITLE
Handle older analyze_traps outputs in notebook and bump package version to 0.8.8

### DIFF
--- a/notebooks/WW-Bulk-Mode-IDs-Workflow.ipynb
+++ b/notebooks/WW-Bulk-Mode-IDs-Workflow.ipynb
@@ -1,157 +1,172 @@
 {
-  "cells": [
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "# Bulk Mode ID Workflow Demo\n",
-        "\n",
-        "This notebook demonstrates how to:\n",
-        "1. Randomize a model\n",
-        "2. Analyze traps **and** eligible MP-bulk IDs\n",
-        "3. Select bulk IDs per layer\n",
-        "4. Remove bulk modes via `remove_modes(...)`\n",
-        "5. Remove trap IDs via `remove_traps(...)`\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import numpy as np\n",
-        "import pandas as pd\n",
-        "import torch\n",
-        "import torch.nn as nn\n",
-        "import weightwatcher as ww\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "class TinyNet(nn.Module):\n",
-        "    def __init__(self):\n",
-        "        super().__init__()\n",
-        "        self.fc1 = nn.Linear(64, 48, bias=False)\n",
-        "        self.fc2 = nn.Linear(48, 32, bias=False)\n",
-        "        with torch.no_grad():\n",
-        "            self.fc1.weight += 2.5 * torch.outer(torch.linspace(0.5, 1.5, 48), torch.linspace(-1.0, 1.0, 64))\n",
-        "\n",
-        "    def forward(self, x):\n",
-        "        return self.fc2(self.fc1(x))\n",
-        "\n",
-        "model = TinyNet()\n",
-        "watcher = ww.WeightWatcher(model=model)\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "randomized_model, trap_state = watcher.randomize_model(model=model, rng=123, return_state=True)\n",
-        "df, trap_state = watcher.analyze_traps(\n",
-        "    randomized_model=randomized_model,\n",
-        "    trap_state=trap_state,\n",
-        "    return_artifacts=True,\n",
-        "    return_bulk_ids=True,\n",
-        "    max_bulk_modes_per_layer=10,\n",
-        "    bulk_sampling_seed=123,\n",
-        "    bulk_sampling_strategy='uniform',\n",
-        "    plot=False,\n",
-        ")\n",
-        "df.head()\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "bulk_df = df.query(\"mode_type == 'bulk'\").copy()\n",
-        "trap_df = df.query(\"mode_type == 'trap'\").copy()\n",
-        "print('bulk rows:', len(bulk_df), 'trap rows:', len(trap_df))\n",
-        "bulk_df[['layer_id','bulk_id','svd_mode_index','eigenvalue']].head()\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "bulk_ids_by_layer = (\n",
-        "    bulk_df.groupby('layer_id')['bulk_id']\n",
-        "    .apply(lambda s: list(map(int, s.head(2))))\n",
-        "    .to_dict()\n",
-        ")\n",
-        "bulk_ids_by_layer\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "bulk_ablated_model = watcher.remove_modes(\n",
-        "    mode_ids_by_layer=bulk_ids_by_layer,\n",
-        "    mode_type='bulk',\n",
-        "    randomized_model=randomized_model,\n",
-        "    trap_state=trap_state,\n",
-        "    plot=False,\n",
-        ")\n",
-        "bulk_ablated_model\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "if len(trap_df) > 0:\n",
-        "    lid = int(trap_df.iloc[0]['layer_id'])\n",
-        "    tid = int(trap_df.iloc[0]['trap_id'])\n",
-        "    trap_ablated_model = watcher.remove_traps(\n",
-        "        randomized_model=randomized_model,\n",
-        "        trap_state=trap_state,\n",
-        "        bulk_ids_by_layer=None,\n",
-        "        trap_indices=[tid],\n",
-        "        mode_type='trap',\n",
-        "        plot=False,\n",
-        "    )\n",
-        "    print('Removed trap_id', tid, 'from layer', lid)\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Notes\n",
-        "- Public `trap_id` and `bulk_id` are 1-based.\n",
-        "- Internal `svd_mode_index` is 0-based for debugging/mapping.\n",
-        "- `trap_state['layers'][layer_id]` stores per-layer mappings (`trap_id_to_svd_index`, `bulk_id_to_svd_index`).\n"
-      ]
-    }
-  ],
-  "metadata": {
-    "kernelspec": {
-      "display_name": "Python 3",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.x"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bulk Mode ID Workflow Demo\n",
+    "\n",
+    "This notebook demonstrates how to:\n",
+    "1. Randomize a model\n",
+    "2. Analyze traps **and** eligible MP-bulk IDs\n",
+    "3. Select bulk IDs per layer\n",
+    "4. Remove bulk modes via `remove_modes(...)`\n",
+    "5. Remove trap IDs via `remove_traps(...)`\n"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import torch\n",
+    "import torch.nn as nn\n",
+    "import weightwatcher as ww\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TinyNet(nn.Module):\n",
+    "    def __init__(self):\n",
+    "        super().__init__()\n",
+    "        self.fc1 = nn.Linear(64, 48, bias=False)\n",
+    "        self.fc2 = nn.Linear(48, 32, bias=False)\n",
+    "        with torch.no_grad():\n",
+    "            self.fc1.weight += 2.5 * torch.outer(torch.linspace(0.5, 1.5, 48), torch.linspace(-1.0, 1.0, 64))\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.fc2(self.fc1(x))\n",
+    "\n",
+    "model = TinyNet()\n",
+    "watcher = ww.WeightWatcher(model=model)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "randomized_model, trap_state = watcher.randomize_model(model=model, rng=123, return_state=True)\n",
+    "df, trap_state = watcher.analyze_traps(\n",
+    "    randomized_model=randomized_model,\n",
+    "    trap_state=trap_state,\n",
+    "    return_artifacts=True,\n",
+    "    return_bulk_ids=True,\n",
+    "    max_bulk_modes_per_layer=10,\n",
+    "    bulk_sampling_seed=123,\n",
+    "    bulk_sampling_strategy='uniform',\n",
+    "    plot=False,\n",
+    ")\n",
+    "df.head()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if 'mode_type' in df.columns:\n",
+    "    bulk_df = df.query(\"mode_type == 'bulk'\").copy()\n",
+    "    trap_df = df.query(\"mode_type == 'trap'\").copy()\n",
+    "else:\n",
+    "    # Backward-compat path: older analyze_traps outputs only trap rows\n",
+    "    bulk_df = pd.DataFrame(columns=df.columns)\n",
+    "    trap_df = df.copy()\n",
+    "print('bulk rows:', len(bulk_df), 'trap rows:', len(trap_df))\n",
+    "if len(bulk_df) > 0 and all(c in bulk_df.columns for c in ['layer_id','bulk_id','svd_mode_index','eigenvalue']):\n",
+    "    bulk_df[['layer_id','bulk_id','svd_mode_index','eigenvalue']].head()\n",
+    "else:\n",
+    "    print('No bulk rows/columns available in this run.')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if len(bulk_df) == 0 or 'bulk_id' not in bulk_df.columns:\n",
+    "    bulk_ids_by_layer = {}\n",
+    "    print('No bulk IDs available.')\n",
+    "else:\n",
+    "    bulk_ids_by_layer = (\n",
+    "        bulk_df.groupby('layer_id')['bulk_id']\n",
+    "        .apply(lambda s: list(map(int, s.head(2))))\n",
+    "        .to_dict()\n",
+    "    )\n",
+    "bulk_ids_by_layer\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if bulk_ids_by_layer:\n",
+    "    bulk_ablated_model = watcher.remove_modes(\n",
+    "        mode_ids_by_layer=bulk_ids_by_layer,\n",
+    "        mode_type='bulk',\n",
+    "        randomized_model=randomized_model,\n",
+    "        trap_state=trap_state,\n",
+    "        plot=False,\n",
+    "    )\n",
+    "    bulk_ablated_model\n",
+    "else:\n",
+    "    print('Skipping bulk ablation: no sampled bulk IDs were returned.')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if len(trap_df) > 0:\n",
+    "    lid = int(trap_df.iloc[0]['layer_id'])\n",
+    "    tid = int(trap_df.iloc[0]['trap_id'])\n",
+    "    trap_ablated_model = watcher.remove_traps(\n",
+    "        randomized_model=randomized_model,\n",
+    "        trap_state=trap_state,\n",
+    "        bulk_ids_by_layer=None,\n",
+    "        trap_indices=[tid],\n",
+    "        mode_type='trap',\n",
+    "        plot=False,\n",
+    "    )\n",
+    "    print('Removed trap_id', tid, 'from layer', lid)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "- Public `trap_id` and `bulk_id` are 1-based.\n",
+    "- Internal `svd_mode_index` is 0-based for debugging/mapping.\n",
+    "- `trap_state['layers'][layer_id]` stores per-layer mappings (`trap_id_to_svd_index`, `bulk_id_to_svd_index`).\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/weightwatcher/__init__.py
+++ b/weightwatcher/__init__.py
@@ -20,7 +20,7 @@ from .compute_trace import ComputeTrace
 
 __name__ = "weightwatcher"
 
-__version__ = "0.8.7"
+__version__ = "0.8.8"
 
 __license__ = "Apache License, Version 2.0"
 __description__ = "Diagnostic Tool for Deep Neural Networks"


### PR DESCRIPTION
### Motivation
- Make the WW-Bulk-Mode-IDs-Workflow notebook robust to older `analyze_traps` outputs that do not include `mode_type`/bulk rows so the demo does not crash.
- Bump the package version to reflect the release increment.

### Description
- Update `notebooks/WW-Bulk-Mode-IDs-Workflow.ipynb` to check for the presence of `mode_type` and provide a backward-compatible path that creates an empty `bulk_df` and treats all rows as trap rows when bulk IDs are not returned.
- Add guards to safely handle missing `bulk_id`/bulk rows when constructing `bulk_ids_by_layer` and skip `remove_modes(...)` when no sampled bulk IDs are available, while printing informative messages.
- Bump `__version__` in `weightwatcher/__init__.py` from `0.8.7` to `0.8.8`.

### Testing
- Ran the repository test suite with `pytest` and all tests passed.
- Executed the updated notebook flow against both an output that contains `mode_type` and a simulated older output that omits bulk rows to verify the backward-compatibility path; both runs completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a77bcb98832085dcf900b2b6f765)