### PR TITLE
Test: pass randomized_model and trap_state into analyze_traps

### DIFF
--- a/tests/test_analyze_traps.py
+++ b/tests/test_analyze_traps.py
@@ -78,7 +78,14 @@ class TestAnalyzeTraps(unittest.TestCase):
 
     def test_analyze_traps_no_powerlaw_columns_required(self):
         np.random.seed(123)
-        df = self.watcher.analyze_traps(plot=False, savefig=False)
+        randomized_model, trap_state = self.watcher.randomize_model(model=self.model, rng=123, return_state=True)
+        df, _ = self.watcher.analyze_traps(
+            randomized_model=randomized_model,
+            trap_state=trap_state,
+            return_artifacts=True,
+            plot=False,
+            savefig=False,
+        )
         self.assertNotIn("alpha", df.columns)
         self.assertNotIn("xmin", df.columns)
         self.assertNotIn("xmax", df.columns)


### PR DESCRIPTION
### Motivation
- Ensure `analyze_traps` is exercised with an explicit `randomized_model` and `trap_state` so the test verifies that power-law columns (`alpha`, `xmin`, `xmax`) are not required when artifacts are provided.

### Description
- Update `test_analyze_traps_no_powerlaw_columns_required` to call `randomize_model` to get `randomized_model` and `trap_state`, then call `analyze_traps` with `randomized_model=randomized_model`, `trap_state=trap_state`, and `return_artifacts=True` while keeping `plot=False` and `savefig=False`.

### Testing
- Ran `pytest tests/test_analyze_traps.py::TestAnalyzeTraps::test_analyze_traps_no_powerlaw_columns_required` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6cd43988c8320b29baff1c7f8631d)