### PR TITLE
Allow remove_traps to handle CONV1D (2D linear) layers and add unit test

### DIFF
--- a/tests/test_remove_traps.py
+++ b/tests/test_remove_traps.py
@@ -34,6 +34,20 @@ class FakeDenseFrameworkLayer(FrameworkLayer):
         self._W = W.copy()
 
 
+
+
+class FakeConv1DFrameworkLayer(FakeDenseFrameworkLayer):
+    def __init__(self, W):
+        super().__init__(W)
+        self.the_type = LAYER_TYPE.CONV1D
+        self.name = "fake_conv1d"
+        self.longname = "fake_conv1d"
+
+
+def make_conv1d_ww_layer(W):
+    return WWLayer(FakeConv1DFrameworkLayer(W), params=make_test_params())
+
+
 def random_unit_vector(rng, n):
     x = rng.standard_normal(n)
     return x / np.linalg.norm(x)
@@ -99,6 +113,19 @@ def _two_trap_setup(seed=7, n=96, noise_std=0.03, s1=12.0, s2=8.5):
     W = W_base + T1 + T2
     return W, (T1, T2), (u1, v1, u2, v2)
 
+
+
+
+def test_remove_traps_supports_conv1d_like_2d_linear():
+    watcher = WeightWatcher(model=None)
+    W, _, _, _ = _single_trap_setup(seed=4242)
+    ww_layer = make_conv1d_ww_layer(W)
+
+    watcher.apply_remove_traps(ww_layer, trap_indices=[1], params=make_test_params(), seed=123)
+    W_new = ww_layer.framework_layer._W
+
+    assert W_new.shape == W.shape
+    assert not np.allclose(W_new, W)
 
 def test_remove_traps_single_trap_flow():
     watcher = WeightWatcher(model=None)

--- a/weightwatcher/remove_traps.py
+++ b/weightwatcher/remove_traps.py
@@ -208,8 +208,9 @@ def apply_remove_traps(ww, ww_layer, trap_indices, params=None, seed=None, rng=N
     if trap_indices is None or len(trap_indices) == 0:
         raise ValueError("trap_indices must be a non-empty list of 1-based indices")
 
-    if ww_layer.the_type != LAYER_TYPE.DENSE or len(ww_layer.Wmats) != 1 or ww_layer.Wmats[0].ndim != 2:
-        raise NotImplementedError("remove_traps currently supports single 2D dense matrices only")
+    supported_types = {LAYER_TYPE.DENSE, LAYER_TYPE.CONV1D}
+    if ww_layer.the_type not in supported_types or len(ww_layer.Wmats) != 1 or ww_layer.Wmats[0].ndim != 2:
+        raise NotImplementedError("remove_traps currently supports single 2D dense/conv1d matrices only")
 
     requested = sorted(set(trap_indices))
     if any(idx < 1 for idx in requested):


### PR DESCRIPTION
### Motivation
- `apply_remove_traps` previously only supported single 2D dense matrices and should also support Conv1D layers that are represented as 2D linear weight matrices.

### Description
- Extend supported layer types in `apply_remove_traps` to accept `LAYER_TYPE.CONV1D` in addition to `LAYER_TYPE.DENSE`, and update the error message accordingly.  
- Add `FakeConv1DFrameworkLayer` and `make_conv1d_ww_layer` helpers to `tests/test_remove_traps.py` to emulate conv1d-like 2D linear layers.  
- Add `test_remove_traps_supports_conv1d_like_2d_linear` to verify `apply_remove_traps` runs on a conv1d-like `WWLayer` and modifies weights without changing shape.

### Testing
- Ran the tests in `tests/test_remove_traps.py` with `pytest`, and the suite (including the new `test_remove_traps_supports_conv1d_like_2d_linear`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa366d3be48320813704a84f150f52)